### PR TITLE
Add useCurrentScope to Resource effect

### DIFF
--- a/effectful/effectful.cabal
+++ b/effectful/effectful.cabal
@@ -115,6 +115,7 @@ test-suite test
     other-modules:  AsyncTests
                     ConcurrencyTests
                     ErrorTests
+                    ResourceTests
                     StateTests
                     Utils
                     -- These are examples; We do not actually run them but list

--- a/effectful/tests/Main.hs
+++ b/effectful/tests/Main.hs
@@ -5,6 +5,7 @@ import Test.Tasty
 import AsyncTests
 import ConcurrencyTests
 import ErrorTests
+import ResourceTests
 import StateTests
 
 main :: IO ()
@@ -12,5 +13,6 @@ main = defaultMain $ testGroup "effectful"
   [ asyncTests
   , concurrencyTests
   , errorTests
+  , resourceTests
   , stateTests
   ]

--- a/effectful/tests/ResourceTests.hs
+++ b/effectful/tests/ResourceTests.hs
@@ -1,0 +1,32 @@
+module ResourceTests
+  ( resourceTests
+  ) where
+
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+import           Effectful
+import           Effectful.Resource
+import           UnliftIO                       ( MonadUnliftIO
+                                                , modifyMVar_
+                                                , newMVar
+                                                , readMVar
+                                                )
+import qualified Utils                         as U
+
+resourceTests :: TestTree
+resourceTests = testGroup "Resource" [testCase "nested" test_nested]
+
+test_nested :: Assertion
+test_nested = runEff $ do
+  rV <- newMVar []
+  let step :: MonadUnliftIO m => Int -> m ()
+      step n = modifyMVar_ rV (pure . (n :))
+  runResource $ do
+    step 1
+    _ <- register (step 4)
+    _ <- runResource $ do
+      register (step 2)
+    step 3
+  r <- readMVar rV
+  U.assertEqual "correct order" [1, 2, 3, 4] (reverse r)


### PR DESCRIPTION
Supersedes https://github.com/arybczak/effectful/pull/28

As first suggested here: https://github.com/snoyberg/conduit/issues/436#issuecomment-616345570