### PR TITLE
Concurrent effect

### DIFF
--- a/effectful/effectful.cabal
+++ b/effectful/effectful.cabal
@@ -72,12 +72,14 @@ library
     hs-source-dirs:  src
 
     exposed-modules: Effectful
-                     Effectful.Concurrent
+                     Effectful.Concurrent.Async
                      Effectful.Environment
                      Effectful.Process
                      Effectful.Resource
                      Effectful.Temporary
                      Effectful.Timeout
+
+    other-modules: Effectful.Concurrent.Internal
 
     reexported-modules:    Effectful.Error
                          , Effectful.Error.Dynamic

--- a/effectful/effectful.cabal
+++ b/effectful/effectful.cabal
@@ -73,6 +73,7 @@ library
 
     exposed-modules: Effectful
                      Effectful.Concurrent.Async
+                     Effectful.Concurrent.Base
                      Effectful.Environment
                      Effectful.Process
                      Effectful.Resource

--- a/effectful/effectful.cabal
+++ b/effectful/effectful.cabal
@@ -72,7 +72,7 @@ library
     hs-source-dirs:  src
 
     exposed-modules: Effectful
-                     Effectful.Async
+                     Effectful.Concurrent
                      Effectful.Environment
                      Effectful.Process
                      Effectful.Resource

--- a/effectful/src/Effectful/Concurrent.hs
+++ b/effectful/src/Effectful/Concurrent.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE UndecidableInstances #-}
-module Effectful.Async
-  ( -- * Async effect
-    AsyncE
-  , runAsyncE
+module Effectful.Concurrent
+  ( -- * Concurrent effect
+    Concurrent
+  , runConcurrent
 
   -- * Asynchronous actions
   , Async
@@ -89,38 +89,38 @@ import Effectful.Internal.Monad
 -- /Note:/ thread local state changes in 'Eff' operations run asynchronously
 -- will not affect the parent thread.
 --
--- /TODO:/ write about 'AsyncE' not respecting scoped operations.
-data AsyncE :: Effect where
-  AsyncE :: AsyncE m r
+-- /TODO:/ write about 'Concurrent' not respecting scoped operations.
+data Concurrent :: Effect where
+  Concurrent :: Concurrent m r
 
-runAsyncE :: IOE :> es => Eff (AsyncE : es) a -> Eff es a
-runAsyncE = evalEffect (IdE AsyncE)
+runConcurrent :: IOE :> es => Eff (Concurrent : es) a -> Eff es a
+runConcurrent = evalEffect (IdE Concurrent)
 
 ----------------------------------------
 -- Operations
 
 -- | Lifted 'A.async'.
-async :: AsyncE :> es => Eff es a -> Eff es (Async a)
+async :: Concurrent :> es => Eff es a -> Eff es (Async a)
 async = liftAsync A.async
 
 -- | Lifted 'A.asyncBound'.
-asyncBound :: AsyncE :> es => Eff es a -> Eff es (Async a)
+asyncBound :: Concurrent :> es => Eff es a -> Eff es (Async a)
 asyncBound = liftAsync A.asyncBound
 
 -- | Lifted 'A.asyncOn'.
-asyncOn :: AsyncE :> es => Int -> Eff es a -> Eff es (Async a)
+asyncOn :: Concurrent :> es => Int -> Eff es a -> Eff es (Async a)
 asyncOn cpu = liftAsync (A.asyncOn cpu)
 
 -- | Lifted 'A.asyncWithUnmask'.
 asyncWithUnmask
-  :: AsyncE :> es
+  :: Concurrent :> es
   => ((forall b. Eff es b -> Eff es b) -> Eff es a)
   -> Eff es (Async a)
 asyncWithUnmask = liftAsyncWithUnmask A.asyncWithUnmask
 
 -- | Lifted 'A.asyncOnWithUnmask'.
 asyncOnWithUnmask
-  :: AsyncE :> es
+  :: Concurrent :> es
   => Int
   -> ((forall b. Eff es b -> Eff es b) -> Eff es a)
   -> Eff es (Async a)
@@ -128,7 +128,7 @@ asyncOnWithUnmask cpu = liftAsyncWithUnmask (A.asyncOnWithUnmask cpu)
 
 -- | Lifted 'A.withAsync'.
 withAsync
-  :: AsyncE :> es
+  :: Concurrent :> es
   => Eff es a
   -> (Async a -> Eff es b)
   -> Eff es b
@@ -136,7 +136,7 @@ withAsync = liftWithAsync A.withAsync
 
 -- | Lifted 'A.withAsyncBound'.
 withAsyncBound
-  :: AsyncE :> es
+  :: Concurrent :> es
   => Eff es a
   -> (Async a -> Eff es b)
   -> Eff es b
@@ -144,7 +144,7 @@ withAsyncBound = liftWithAsync A.withAsyncBound
 
 -- | Lifted 'A.withAsyncOn'.
 withAsyncOn
-  :: AsyncE :> es
+  :: Concurrent :> es
   => Int
   -> Eff es a
   -> (Async a -> Eff es b)
@@ -153,7 +153,7 @@ withAsyncOn cpu = liftWithAsync (A.withAsyncOn cpu)
 
 -- | Lifted 'A.withAsyncWithUnmask'.
 withAsyncWithUnmask
-  :: AsyncE :> es
+  :: Concurrent :> es
   => ((forall c. Eff es c -> Eff es c) -> Eff es a)
   -> (Async a -> Eff es b)
   -> Eff es b
@@ -161,7 +161,7 @@ withAsyncWithUnmask = liftWithAsyncWithUnmask A.withAsyncWithUnmask
 
 -- | Lifted 'A.withAsyncOnWithUnmask'.
 withAsyncOnWithUnmask
-  :: AsyncE :> es
+  :: Concurrent :> es
   => Int
   -> ((forall c. Eff es c -> Eff es c) -> Eff es a)
   -> (Async a -> Eff es b)
@@ -169,60 +169,60 @@ withAsyncOnWithUnmask
 withAsyncOnWithUnmask cpu = liftWithAsyncWithUnmask (A.withAsyncOnWithUnmask cpu)
 
 -- | Lifted 'A.wait'.
-wait :: AsyncE :> es => Async a -> Eff es a
+wait :: Concurrent :> es => Async a -> Eff es a
 wait = unsafeEff_ . A.wait
 
 -- | Lifted 'A.poll'.
 poll
-  :: AsyncE :> es
+  :: Concurrent :> es
   => Async a
   -> Eff es (Maybe (Either SomeException a))
 poll = unsafeEff_ . A.poll
 
 -- | Lifted 'A.cancel'.
-cancel :: AsyncE :> es => Async a -> Eff es ()
+cancel :: Concurrent :> es => Async a -> Eff es ()
 cancel = unsafeEff_ . A.cancel
 
 -- | Lifted 'A.cancelWith'.
-cancelWith :: (Exception e, AsyncE :> es) => Async a -> e -> Eff es ()
+cancelWith :: (Exception e, Concurrent :> es) => Async a -> e -> Eff es ()
 cancelWith a = unsafeEff_ . A.cancelWith a
 
 -- | Lifted 'A.uninterruptibleCancel'.
-uninterruptibleCancel :: AsyncE :> es => Async a -> Eff es ()
+uninterruptibleCancel :: Concurrent :> es => Async a -> Eff es ()
 uninterruptibleCancel = unsafeEff_ . A.uninterruptibleCancel
 
 -- | Lifted 'A.waitCatch'.
 waitCatch
-  :: AsyncE :> es
+  :: Concurrent :> es
   => Async a
   -> Eff es (Either SomeException a)
 waitCatch = unsafeEff_ . A.waitCatch
 
 -- | Lifted 'A.waitAny'.
-waitAny :: AsyncE :> es => [Async a] -> Eff es (Async a, a)
+waitAny :: Concurrent :> es => [Async a] -> Eff es (Async a, a)
 waitAny = unsafeEff_ . A.waitAny
 
 -- | Lifted 'A.waitAnyCatch'.
 waitAnyCatch
-  :: AsyncE :> es
+  :: Concurrent :> es
   => [Async a]
   -> Eff es (Async a, Either SomeException a)
 waitAnyCatch = unsafeEff_ . A.waitAnyCatch
 
 -- | Lifted 'A.waitAnyCancel'.
-waitAnyCancel :: AsyncE :> es => [Async a] -> Eff es (Async a, a)
+waitAnyCancel :: Concurrent :> es => [Async a] -> Eff es (Async a, a)
 waitAnyCancel = unsafeEff_ . A.waitAnyCancel
 
 -- | Lifted 'A.waitAnyCatchCancel'.
 waitAnyCatchCancel
-  :: AsyncE :> es
+  :: Concurrent :> es
   => [Async a]
   -> Eff es (Async a, Either SomeException a)
 waitAnyCatchCancel = unsafeEff_ . A.waitAnyCatchCancel
 
 -- | Lifted 'A.waitEither'.
 waitEither
-  :: AsyncE :> es
+  :: Concurrent :> es
   => Async a
   -> Async b
   -> Eff es (Either a b)
@@ -230,7 +230,7 @@ waitEither a b = unsafeEff_ $ A.waitEither a b
 
 -- | Lifted 'A.waitEitherCatch'.
 waitEitherCatch
-  :: AsyncE :> es
+  :: Concurrent :> es
   => Async a
   -> Async b
   -> Eff es (Either (Either SomeException a) (Either SomeException b))
@@ -238,7 +238,7 @@ waitEitherCatch a b = unsafeEff_ $ A.waitEitherCatch a b
 
 -- | Lifted 'A.waitEitherCancel'.
 waitEitherCancel
-  :: AsyncE :> es
+  :: Concurrent :> es
   => Async a
   -> Async b
   -> Eff es (Either a b)
@@ -246,53 +246,53 @@ waitEitherCancel a b = unsafeEff_ $ A.waitEitherCancel a b
 
 -- | Lifted 'A.waitEitherCatchCancel'.
 waitEitherCatchCancel
-  :: AsyncE :> es
+  :: Concurrent :> es
   => Async a
   -> Async b
   -> Eff es (Either (Either SomeException a) (Either SomeException b))
 waitEitherCatchCancel a b = unsafeEff_  $ A.waitEitherCatch a b
 
 -- | Lifted 'A.waitEither_'.
-waitEither_ :: AsyncE :> es => Async a -> Async b -> Eff es ()
+waitEither_ :: Concurrent :> es => Async a -> Async b -> Eff es ()
 waitEither_ a b = unsafeEff_ $ A.waitEither_ a b
 
 -- | Lifted 'A.waitBoth'.
-waitBoth :: AsyncE :> es => Async a -> Async b -> Eff es (a, b)
+waitBoth :: Concurrent :> es => Async a -> Async b -> Eff es (a, b)
 waitBoth a b = unsafeEff_ $ A.waitBoth a b
 
 -- | Lifted 'A.link'.
-link :: AsyncE :> es => Async a -> Eff es ()
+link :: Concurrent :> es => Async a -> Eff es ()
 link = unsafeEff_ . A.link
 
 -- | Lifted 'A.linkOnly'.
-linkOnly :: AsyncE :> es => (SomeException -> Bool) -> Async a -> Eff es ()
+linkOnly :: Concurrent :> es => (SomeException -> Bool) -> Async a -> Eff es ()
 linkOnly f = unsafeEff_ . A.linkOnly f
 
 -- | Lifted 'A.link2'.
-link2 :: AsyncE :> es => Async a -> Async b -> Eff es ()
+link2 :: Concurrent :> es => Async a -> Async b -> Eff es ()
 link2 a b = unsafeEff_ $ A.link2 a b
 
 -- | Lifted 'A.link2Only'.
-link2Only :: AsyncE :> es => (SomeException -> Bool) -> Async a -> Async b -> Eff es ()
+link2Only :: Concurrent :> es => (SomeException -> Bool) -> Async a -> Async b -> Eff es ()
 link2Only f a b = unsafeEff_ $ A.link2Only f a b
 
 -- | Lifted 'A.race'.
-race :: AsyncE :> es => Eff es a -> Eff es b -> Eff es (Either a b)
+race :: Concurrent :> es => Eff es a -> Eff es b -> Eff es (Either a b)
 race ma mb = unsafeEff $ \es -> do
   A.race (unEff ma =<< cloneEnv es) (unEff mb =<< cloneEnv es)
 
 -- | Lifted 'A.race_'.
-race_ ::  AsyncE :> es => Eff es a -> Eff es b -> Eff es ()
+race_ ::  Concurrent :> es => Eff es a -> Eff es b -> Eff es ()
 race_ ma mb = unsafeEff $ \es -> do
   A.race_ (unEff ma =<< cloneEnv es) (unEff mb =<< cloneEnv es)
 
 -- | Lifted 'A.concurrently'.
-concurrently :: AsyncE :> es => Eff es a -> Eff es b -> Eff es (a, b)
+concurrently :: Concurrent :> es => Eff es a -> Eff es b -> Eff es (a, b)
 concurrently ma mb = unsafeEff $ \es -> do
   A.concurrently (unEff ma =<< cloneEnv es) (unEff mb =<< cloneEnv es)
 
 -- | Lifted 'A.concurrently_'.
-concurrently_ :: AsyncE :> es => Eff es a -> Eff es b -> Eff es ()
+concurrently_ :: Concurrent :> es => Eff es a -> Eff es b -> Eff es ()
 concurrently_ ma mb = unsafeEff $ \es -> do
   A.concurrently_ (unEff ma =<< cloneEnv es) (unEff mb =<< cloneEnv es)
 
@@ -302,7 +302,7 @@ concurrently_ ma mb = unsafeEff $ \es -> do
 
 -- | Lifted 'A.mapConcurrently'.
 mapConcurrently
-  :: (Traversable f, AsyncE :> es)
+  :: (Traversable f, Concurrent :> es)
   => (a -> Eff es b)
   -> f a
   -> Eff es (f b)
@@ -311,7 +311,7 @@ mapConcurrently f t = unsafeEff $ \es -> do
 
 -- | Lifted 'A.mapConcurrently_'.
 mapConcurrently_
-  :: (Foldable f, AsyncE :> es)
+  :: (Foldable f, Concurrent :> es)
   => (a -> Eff es b)
   -> f a
   -> Eff es ()
@@ -320,7 +320,7 @@ mapConcurrently_ f t = unsafeEff $ \es -> do
 
 -- | Lifted 'A.forConcurrently'.
 forConcurrently
-  :: (Traversable f, AsyncE :> es)
+  :: (Traversable f, Concurrent :> es)
   => f a
   -> (a -> Eff es b)
   -> Eff es (f b)
@@ -329,7 +329,7 @@ forConcurrently t f = unsafeEff $ \es -> do
 
 -- | Lifted 'A.forConcurrently_'.
 forConcurrently_
-  :: (Foldable f, AsyncE :> es)
+  :: (Foldable f, Concurrent :> es)
   => f a
   -> (a -> Eff es b)
   -> Eff es ()
@@ -337,12 +337,12 @@ forConcurrently_ t f = unsafeEff $ \es -> do
   U.forConcurrently_ t (\a -> unEff (f a) =<< cloneEnv es)
 
 -- | Lifted 'A.replicateConcurrently'.
-replicateConcurrently :: AsyncE :> es => Int -> Eff es a -> Eff es [a]
+replicateConcurrently :: Concurrent :> es => Int -> Eff es a -> Eff es [a]
 replicateConcurrently n f = unsafeEff $ \es -> do
   U.replicateConcurrently n (unEff f =<< cloneEnv es)
 
 -- | Lifted 'A.replicateConcurrently_'.
-replicateConcurrently_ :: AsyncE :> es => Int -> Eff es a -> Eff es ()
+replicateConcurrently_ :: Concurrent :> es => Int -> Eff es a -> Eff es ()
 replicateConcurrently_ n f = unsafeEff $ \es -> do
   U.replicateConcurrently_ n (unEff f =<< cloneEnv es)
 
@@ -351,7 +351,7 @@ replicateConcurrently_ n f = unsafeEff $ \es -> do
 
 -- | Lifted 'U.pooledMapConcurrentlyN'.
 pooledMapConcurrentlyN
-  :: (AsyncE :> es, Traversable t)
+  :: (Concurrent :> es, Traversable t)
   => Int
   -> (a -> Eff es b)
   -> t a
@@ -361,7 +361,7 @@ pooledMapConcurrentlyN  threads f t = unsafeEff $ \es -> do
 
 -- | Lifted 'U.pooledMapConcurrently'.
 pooledMapConcurrently
-  :: (AsyncE :> es, Traversable t)
+  :: (Concurrent :> es, Traversable t)
   => (a -> Eff es b)
   -> t a
   -> Eff es (t b)
@@ -370,7 +370,7 @@ pooledMapConcurrently f t = unsafeEff $ \es -> do
 
 -- | Lifted 'U.pooledMapConcurrentlyN'.
 pooledMapConcurrentlyN_
-  :: (AsyncE :> es, Foldable f)
+  :: (Concurrent :> es, Foldable f)
   => Int
   -> (a -> Eff es b)
   -> f a
@@ -380,7 +380,7 @@ pooledMapConcurrentlyN_  threads f t = unsafeEff $ \es -> do
 
 -- | Lifted 'U.pooledMapConcurrently_'.
 pooledMapConcurrently_
-  :: (AsyncE :> es, Foldable f)
+  :: (Concurrent :> es, Foldable f)
   => (a -> Eff es b)
   -> f a
   -> Eff es ()
@@ -389,7 +389,7 @@ pooledMapConcurrently_ f t = unsafeEff $ \es -> do
 
 -- | Lifted 'U.pooledForConcurrentlyN'.
 pooledForConcurrentlyN
-  :: (AsyncE :> es, Traversable t)
+  :: (Concurrent :> es, Traversable t)
   => Int
   -> t a
   -> (a -> Eff es b)
@@ -399,7 +399,7 @@ pooledForConcurrentlyN  threads t f = unsafeEff $ \es -> do
 
 -- | Lifted 'U.pooledForConcurrently'.
 pooledForConcurrently
-  :: (AsyncE :> es, Traversable t)
+  :: (Concurrent :> es, Traversable t)
   => t a
   -> (a -> Eff es b)
   -> Eff es (t b)
@@ -408,7 +408,7 @@ pooledForConcurrently t f = unsafeEff $ \es -> do
 
 -- | Lifted 'U.pooledForConcurrentlyN'.
 pooledForConcurrentlyN_
-  :: (AsyncE :> es, Foldable f)
+  :: (Concurrent :> es, Foldable f)
   => Int
   -> f a
   -> (a -> Eff es b)
@@ -418,7 +418,7 @@ pooledForConcurrentlyN_  threads t f = unsafeEff $ \es -> do
 
 -- | Lifted 'U.pooledForConcurrently_'.
 pooledForConcurrently_
-  :: (AsyncE :> es, Foldable f)
+  :: (Concurrent :> es, Foldable f)
   => f a
   -> (a -> Eff es b)
   -> Eff es ()
@@ -426,22 +426,22 @@ pooledForConcurrently_ t f = unsafeEff $ \es -> do
   U.pooledForConcurrently_ t (\a -> unEff (f a) =<< cloneEnv es)
 
 -- | Lifted 'U.pooledReplicateConcurrentlyN'.
-pooledReplicateConcurrentlyN :: AsyncE :> es => Int -> Int -> Eff es a -> Eff es [a]
+pooledReplicateConcurrentlyN :: Concurrent :> es => Int -> Int -> Eff es a -> Eff es [a]
 pooledReplicateConcurrentlyN threads n f = unsafeEff $ \es -> do
   U.pooledReplicateConcurrentlyN threads n (unEff f =<< cloneEnv es)
 
 -- | Lifted 'U.pooledReplicateConcurrently'.
-pooledReplicateConcurrently :: AsyncE :> es => Int -> Eff es a -> Eff es [a]
+pooledReplicateConcurrently :: Concurrent :> es => Int -> Eff es a -> Eff es [a]
 pooledReplicateConcurrently n f = unsafeEff $ \es -> do
   U.pooledReplicateConcurrently n (unEff f =<< cloneEnv es)
 
 -- | Lifted 'U.pooledReplicateConcurrentlyN_'.
-pooledReplicateConcurrentlyN_ :: AsyncE :> es => Int -> Int -> Eff es a -> Eff es ()
+pooledReplicateConcurrentlyN_ :: Concurrent :> es => Int -> Int -> Eff es a -> Eff es ()
 pooledReplicateConcurrentlyN_ threads n f = unsafeEff $ \es -> do
   U.pooledReplicateConcurrentlyN_ threads n (unEff f =<< cloneEnv es)
 
 -- | Lifted 'U.pooledReplicateConcurrently_'.
-pooledReplicateConcurrently_ :: AsyncE :> es => Int -> Eff es a -> Eff es ()
+pooledReplicateConcurrently_ :: Concurrent :> es => Int -> Eff es a -> Eff es ()
 pooledReplicateConcurrently_ n f = unsafeEff $ \es -> do
   U.pooledReplicateConcurrently_ n (unEff f =<< cloneEnv es)
 
@@ -481,7 +481,7 @@ conc :: Eff es a -> Conc es a
 conc = Action
 
 -- | Lifted 'U.runConc'.
-runConc :: AsyncE :> es => Conc es a -> Eff es a
+runConc :: Concurrent :> es => Conc es a -> Eff es a
 runConc m = unsafeEff $ \es -> U.runConc (unliftConc es m)
   where
     unliftConc :: Env es -> Conc es a -> U.Conc IO a
@@ -502,20 +502,20 @@ newtype Concurrently es a = Concurrently { runConcurrently :: Eff es a }
 instance Functor (Concurrently es) where
   fmap f (Concurrently a) = Concurrently (fmap f a)
 
-instance AsyncE :> es => Applicative (Concurrently es) where
+instance Concurrent :> es => Applicative (Concurrently es) where
   pure = Concurrently . pure
   Concurrently fs <*> Concurrently as =
     Concurrently ((\(f, a) -> f a) <$> concurrently fs as)
 
-instance AsyncE :> es => Alternative (Concurrently es) where
+instance Concurrent :> es => Alternative (Concurrently es) where
   empty = Concurrently . unsafeEff_ . forever $ threadDelay maxBound
   Concurrently as <|> Concurrently bs =
     Concurrently (either id id <$> race as bs)
 
-instance (AsyncE :> es, Semigroup a) => Semigroup (Concurrently es a) where
+instance (Concurrent :> es, Semigroup a) => Semigroup (Concurrently es a) where
   (<>) = liftA2 (<>)
 
-instance (AsyncE :> es, Monoid a) => Monoid (Concurrently es a) where
+instance (Concurrent :> es, Monoid a) => Monoid (Concurrently es a) where
   mempty = pure mempty
 
 ----------------------------------------

--- a/effectful/src/Effectful/Concurrent/Async.hs
+++ b/effectful/src/Effectful/Concurrent/Async.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE UndecidableInstances #-}
-module Effectful.Concurrent
+module Effectful.Concurrent.Async
   ( -- * Concurrent effect
     Concurrent
   , runConcurrent
@@ -80,24 +80,10 @@ import qualified Control.Concurrent.Async as A
 import qualified UnliftIO.Async as U
 import qualified UnliftIO.Internals.Async as I
 
+import Effectful.Concurrent.Internal
 import Effectful.Internal.Effect
 import Effectful.Internal.Env
 import Effectful.Internal.Monad
-
--- | Run 'Eff' operations asynchronously via the @async@ library.
---
--- /Note:/ thread local state changes in 'Eff' operations run asynchronously
--- will not affect the parent thread.
---
--- /TODO:/ write about 'Concurrent' not respecting scoped operations.
-data Concurrent :: Effect where
-  Concurrent :: Concurrent m r
-
-runConcurrent :: IOE :> es => Eff (Concurrent : es) a -> Eff es a
-runConcurrent = evalEffect (IdE Concurrent)
-
-----------------------------------------
--- Operations
 
 -- | Lifted 'A.async'.
 async :: Concurrent :> es => Eff es a -> Eff es (Async a)

--- a/effectful/src/Effectful/Concurrent/Base.hs
+++ b/effectful/src/Effectful/Concurrent/Base.hs
@@ -1,0 +1,200 @@
+module Effectful.Concurrent.Base
+  ( -- * Concurrent effect
+    Concurrent
+  , runConcurrent
+
+    -- * Basic concurrency operations
+  , myThreadId
+  , forkIO
+  , forkFinally
+  , forkIOWithUnmask
+  , killThread
+  , throwTo
+
+    -- ** Threads with affinity
+  , forkOn
+  , forkOnWithUnmask
+  , getNumCapabilities
+  , setNumCapabilities
+  , threadCapability
+
+    -- * Scheduling
+  , yield
+
+    -- ** Waiting
+  , threadDelay
+  , threadWaitRead
+  , threadWaitWrite
+  , threadWaitReadSTM
+  , threadWaitWriteSTM
+
+    -- * Bound threads
+  , forkOS
+  , forkOSWithUnmask
+  , isCurrentThreadBound
+  , runInBoundThread
+  , runInUnboundThread
+
+    -- * Weak references to ThreadIds
+  , mkWeakThreadId
+
+    -- * Re-exports
+  , C.rtsSupportsBoundThreads
+  ) where
+
+import qualified Control.Concurrent as C
+import Control.Exception (Exception, SomeException)
+import Data.Bifunctor (second)
+import System.Mem.Weak (Weak)
+import System.Posix.Types (Fd)
+import UnliftIO.STM (STM)
+
+import Effectful.Concurrent.Internal
+import Effectful.Internal.Effect
+import Effectful.Internal.Env
+import Effectful.Internal.Monad
+
+----------------------------------------
+-- Basic concurrency operations
+
+-- | Lifted 'C.myThreadId'.
+myThreadId :: Concurrent :> es => Eff es C.ThreadId
+myThreadId = unsafeEff_ C.myThreadId
+
+-- | Lifted 'C.forkIO'.
+forkIO :: Concurrent :> es => Eff es () -> Eff es C.ThreadId
+forkIO k = unsafeEff $ \es -> do
+  esF <- cloneEnv es
+  C.forkIO $ unEff k esF
+
+-- | Lifted 'C.forkFinally'.
+forkFinally
+  :: Concurrent :> es
+  => Eff es a
+  -> (Either SomeException a -> Eff es ())
+  -> Eff es C.ThreadId
+forkFinally k cleanup = unsafeEff $ \es -> do
+  esF <- cloneEnv es
+  C.forkFinally (unEff k esF) ((`unEff` esF) . cleanup)
+
+-- | Lifted 'C.forkIOWithUnmask'.
+forkIOWithUnmask
+  :: Concurrent :> es
+  => ((forall a es'. IOE :> es' => Eff es' a -> Eff es' a)
+  -> Eff es ())
+  -> Eff es C.ThreadId
+forkIOWithUnmask f = unsafeEff $ \es -> do
+  esF <- cloneEnv es
+  C.forkIOWithUnmask (\restore -> unEff (f (unsafeLiftMapIO restore)) esF)
+
+-- | Lifted 'C.killThread'.
+killThread :: Concurrent :> es => C.ThreadId -> Eff es ()
+killThread = unsafeEff_ . C.killThread
+
+-- | Lifted 'C.throwTo'.
+throwTo :: (Concurrent :> es, Exception e) => C.ThreadId -> e -> Eff es ()
+throwTo tid = unsafeEff_ . C.throwTo tid
+
+----------------------------------------
+-- Threads with affinity
+
+-- | Lifted 'C.forkOn'.
+forkOn :: Concurrent :> es => Int -> Eff es () -> Eff es C.ThreadId
+forkOn n k = unsafeEff $ \es -> do
+  esF <- cloneEnv es
+  C.forkOn n (unEff k esF)
+
+-- | Lifted 'C.forkOnWithUnmask'.
+forkOnWithUnmask
+  :: Concurrent :> es
+  => Int
+  -> ((forall a es'. IOE :> es' => Eff es' a -> Eff es' a) -> Eff es ())
+  -> Eff es C.ThreadId
+forkOnWithUnmask n f = unsafeEff $ \es -> do
+  esF <- cloneEnv es
+  C.forkOnWithUnmask n (\restore -> unEff (f (unsafeLiftMapIO restore)) esF)
+
+-- | Lifted 'C.getNumCapabilities'.
+getNumCapabilities :: Concurrent :> es => Eff es Int
+getNumCapabilities = unsafeEff_ C.getNumCapabilities
+
+-- | Lifted 'C.setNumCapabilities'.
+setNumCapabilities :: Concurrent :> es => Int -> Eff es ()
+setNumCapabilities = unsafeEff_ . C.setNumCapabilities
+
+-- | Lifted 'C.threadCapability'.
+threadCapability :: Concurrent :> es => C.ThreadId -> Eff es (Int, Bool)
+threadCapability = unsafeEff_ . C.threadCapability
+
+----------------------------------------
+-- Scheduling
+
+-- | Lifted 'C.yield'.
+yield :: Concurrent :> es => Eff es ()
+yield = unsafeEff_ C.yield
+
+----------------------------------------
+-- Waiting
+
+-- | Lifted 'C.threadDelay'.
+threadDelay :: Concurrent :> es => Int -> Eff es ()
+threadDelay = unsafeEff_ . C.threadDelay
+
+-- | Lifted 'C.threadWaitRead'.
+threadWaitRead :: Concurrent :> es => Fd -> Eff es ()
+threadWaitRead = unsafeEff_ . C.threadWaitRead
+
+-- | Lifted 'C.threadWaitWrite'.
+threadWaitWrite :: Concurrent :> es => Fd -> Eff es ()
+threadWaitWrite = unsafeEff_ . C.threadWaitWrite
+
+-- | Lifted 'C.threadWaitReadSTM'.
+threadWaitReadSTM :: Concurrent :> es => Fd -> Eff es (STM (), Eff es ())
+threadWaitReadSTM fd = unsafeEff_ $ do
+  second unsafeEff_ <$> C.threadWaitReadSTM fd
+
+-- | Lifted 'C.threadWaitWriteSTM'.
+threadWaitWriteSTM :: Concurrent :> es => Fd -> Eff es (STM (), Eff es ())
+threadWaitWriteSTM fd = unsafeEff_ $ do
+  second unsafeEff_ <$> C.threadWaitWriteSTM fd
+
+----------------------------------------
+-- Bound threads
+
+-- | Lifted 'C.forkOS'.
+forkOS :: Concurrent :> es => Eff es () -> Eff es C.ThreadId
+forkOS k = unsafeEff $ \es -> do
+  esF <- cloneEnv es
+  C.forkOS $ unEff k esF
+
+-- | Lifted 'E.forkOSWithUnmask'.
+forkOSWithUnmask
+  :: Concurrent :> es
+  => ((forall a es'. IOE :> es' => Eff es' a -> Eff es' a) -> Eff es ())
+  -> Eff es C.ThreadId
+forkOSWithUnmask f = unsafeEff $ \es -> do
+  esF <- cloneEnv es
+  C.forkOSWithUnmask (\restore -> unEff (f (unsafeLiftMapIO restore)) esF)
+
+-- | Lifted 'C.isCurrentThreadBound'.
+isCurrentThreadBound :: Concurrent :> es => Eff es Bool
+isCurrentThreadBound = unsafeEff_ C.isCurrentThreadBound
+
+-- | Lifted 'C.runInBoundThread'.
+runInBoundThread :: Concurrent :> es => Eff es a -> Eff es a
+runInBoundThread k = unsafeEff $ \es -> do
+  esF <- cloneEnv es
+  C.runInBoundThread $ unEff k esF
+
+-- | Lifted 'C.runInUnboundThread'.
+runInUnboundThread :: Concurrent :> es => Eff es a -> Eff es a
+runInUnboundThread k = unsafeEff $ \es -> do
+  esF <- cloneEnv es
+  C.runInUnboundThread $ unEff k esF
+
+----------------------------------------
+-- Weak references to ThreadIds
+
+-- | Lifted 'C.mkWeakThreadId'.
+mkWeakThreadId :: Concurrent :> es => C.ThreadId -> Eff es (Weak C.ThreadId)
+mkWeakThreadId = unsafeEff_ . C.mkWeakThreadId

--- a/effectful/src/Effectful/Concurrent/Internal.hs
+++ b/effectful/src/Effectful/Concurrent/Internal.hs
@@ -1,0 +1,20 @@
+module Effectful.Concurrent.Internal
+  ( -- * Concurrent effect
+    Concurrent
+  , runConcurrent
+  ) where
+
+import Effectful.Internal.Effect
+import Effectful.Internal.Monad
+
+-- | Run 'Eff' operations asynchronously via the @async@ library.
+--
+-- /Note:/ thread local state changes in 'Eff' operations run asynchronously
+-- will not affect the parent thread.
+--
+-- /TODO:/ write about 'Concurrent' not respecting scoped operations.
+data Concurrent :: Effect where
+  Concurrent :: Concurrent m r
+
+runConcurrent :: IOE :> es => Eff (Concurrent : es) a -> Eff es a
+runConcurrent = evalEffect (IdE Concurrent)

--- a/effectful/tests/AsyncTests.hs
+++ b/effectful/tests/AsyncTests.hs
@@ -7,7 +7,7 @@ import Test.Tasty.HUnit
 import qualified Data.Set as S
 
 import Effectful
-import Effectful.Concurrent
+import Effectful.Concurrent.Async
 import Effectful.Error
 import Effectful.State.Dynamic
 

--- a/effectful/tests/AsyncTests.hs
+++ b/effectful/tests/AsyncTests.hs
@@ -7,7 +7,7 @@ import Test.Tasty.HUnit
 import qualified Data.Set as S
 
 import Effectful
-import Effectful.Async
+import Effectful.Concurrent
 import Effectful.Error
 import Effectful.State.Dynamic
 
@@ -23,7 +23,7 @@ asyncTests = testGroup "Async"
   ]
 
 test_localState :: Assertion
-test_localState = runEff . runAsyncE . evalLocalState x $ do
+test_localState = runEff . runConcurrent . evalLocalState x $ do
   replicateConcurrently_ 2 $ do
     r <- goDownward 0
     U.assertEqual "expected result" x r
@@ -41,7 +41,7 @@ test_localState = runEff . runAsyncE . evalLocalState x $ do
         else goDownward $ acc + 1
 
 test_sharedState :: Assertion
-test_sharedState = runEff . runAsyncE . evalSharedState (S.empty @Int) $ do
+test_sharedState = runEff . runConcurrent . evalSharedState (S.empty @Int) $ do
   concurrently_ (addWhen even x) (addWhen odd x)
   U.assertEqual "expected result" (S.fromList [1..x]) =<< get
   where
@@ -57,7 +57,7 @@ test_sharedState = runEff . runAsyncE . evalSharedState (S.empty @Int) $ do
         addWhen f $ n - 1
 
 test_errorHandling :: Assertion
-test_errorHandling = runEff . runAsyncE . evalSharedState (0::Int) $ do
+test_errorHandling = runEff . runConcurrent . evalSharedState (0::Int) $ do
   r <- runError $ concurrently_
     (liftIO (threadDelay 10000) >> throwError err)
     (modify (+x))
@@ -73,7 +73,7 @@ test_errorHandling = runEff . runAsyncE . evalSharedState (0::Int) $ do
     err = "thrown from async"
 
 test_asyncWithUnmask :: Assertion
-test_asyncWithUnmask = runEff . runAsyncE . evalLocalState "initial" $ do
+test_asyncWithUnmask = runEff . runConcurrent . evalLocalState "initial" $ do
   x <- asyncWithUnmask $ \unmask -> do
     liftIO $ threadDelay 10000
     r1 <- get @String -- 2
@@ -88,7 +88,7 @@ test_asyncWithUnmask = runEff . runAsyncE . evalLocalState "initial" $ do
     (inner1, inner2, outer)
 
 test_pooledWorkers :: Assertion
-test_pooledWorkers = runEff . runAsyncE . evalLocalState (0::Int) $ do
+test_pooledWorkers = runEff . runConcurrent . evalLocalState (0::Int) $ do
   x <- pooledForConcurrentlyN threads [1..n] $ \k -> do
     r <- get @Int
     modify @Int (+1)

--- a/effectful/tests/EnvironmentTests.hs
+++ b/effectful/tests/EnvironmentTests.hs
@@ -18,10 +18,11 @@ environmentTests = testGroup "Environment"
 
 test_setAndGet :: Assertion
 test_setAndGet = runEff . runEnvironment $ do
-  let n = "EFFECTFUL_TEST1"
-  setEnv n "value"
+  let expected = "value"
+      n = "EFFECTFUL_TEST1"
+  setEnv n expected
   v <- getEnv n
-  U.assertEqual "environment variable not set" v "value"
+  U.assertEqual "environment variable not set" expected v
 
 test_unsetAndGet :: Assertion
 test_unsetAndGet = runEff . runEnvironment $ do
@@ -33,10 +34,10 @@ test_withArgs :: Assertion
 test_withArgs = runEff . runEnvironment $ do
   let expected = ["effectful-test"]
   args <- withArgs expected getArgs
-  U.assertEqual "correct arguments" args expected
+  U.assertEqual "correct arguments" expected args
 
 test_withProg :: Assertion
 test_withProg = runEff . runEnvironment $ do
   let expected = "effectful-test"
   n <- withProgName expected getProgName
-  U.assertEqual "correct program name" n expected
+  U.assertEqual "correct program name" expected n


### PR DESCRIPTION
This PR replaces the `AsyncE` effect with an effect named `Concurrent`.
The code of the former `AsyncE` effect is now located in the `Effectful.Concurrent.Async` module.

In addition to that we add a new module `Effectful.Concurrent.Base` which contains the concurrency primitives found in the `Control.Concurrent` module of the `base` package.

Both `Effectful.Concurrent.Async` and `Effectful.Concurrent.Base` are part of the `Concurrent` effect which lives in an internal module `Effectful.Concurrent.Internal` and gets re-exported by the two modules.