### PR TITLE
Tried refining interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 stack.yaml
 stack.yaml.lock
 cabal.project.local
+.vscode

--- a/effectful-core/effectful-core.cabal
+++ b/effectful-core/effectful-core.cabal
@@ -51,6 +51,7 @@ common language
                         TypeApplications
                         TypeFamilies
                         TypeOperators
+                        AllowAmbiguousTypes
 
 library effectful-internal-utils
     import:          language

--- a/effectful-core/src/Effectful.hs
+++ b/effectful-core/src/Effectful.hs
@@ -32,8 +32,10 @@ module Effectful
   , send
 
   -- ** Basic handlers
-  , interpret
-  , reinterpret
+  , runDynamic
+  , rerunDynamic
+  , interpretDynamic
+  , reinterpretDynamic
 
   -- ** Handling local 'Eff' computations
   , LocalEnv

--- a/effectful-core/src/Effectful.hs
+++ b/effectful-core/src/Effectful.hs
@@ -26,16 +26,29 @@ module Effectful
   -- * 'Effect' handlers
   , EffectStyle
   , DynamicEffect
-  , StaticEffect
+  , StaticEffect(..)
 
   -- ** Sending operations to the handler
   , send
 
   -- ** Basic handlers
+  , DynamicEffectHandler
   , runDynamic
   , rerunDynamic
   , interpretDynamic
   , reinterpretDynamic
+
+    -- ** Extending the environment
+  , runStatic
+  , evalStatic
+  , execStatic
+
+    -- ** Static retrieval and update
+  , getStatic
+  , putStatic
+  , stateStatic
+  , stateStaticM
+  , localStatic
 
   -- ** Handling local 'Eff' computations
   , LocalEnv

--- a/effectful-core/src/Effectful.hs
+++ b/effectful-core/src/Effectful.hs
@@ -24,6 +24,9 @@ module Effectful
   , withEffToIO
 
   -- * 'Effect' handlers
+  , EffectStyle
+  , DynamicEffect
+  , StaticEffect
 
   -- ** Sending operations to the handler
   , send
@@ -55,4 +58,5 @@ module Effectful
   ) where
 
 import Effectful.Dispatch.Dynamic
+import Effectful.Dispatch.Static
 import Effectful.Monad

--- a/effectful-core/src/Effectful/Dispatch/Dynamic.hs
+++ b/effectful-core/src/Effectful/Dispatch/Dynamic.hs
@@ -5,7 +5,7 @@ module Effectful.Dispatch.Dynamic
 
   -- * Handling effects
   , EffectHandler
-  , HandlerA(..)
+  , DynamicEffect(..)
   , interpret
   , reinterpret
 
@@ -46,18 +46,18 @@ import Effectful.Internal.Monad
 
 -- | Interpret an effect.
 interpret
-  :: (EffectStyle e ~ HandlerA)
+  :: (EffectStyle e ~ DynamicEffect)
   => EffectHandler e es
   -- ^ The effect handler.
   -> Eff (e : es) a
   -> Eff      es  a
 interpret handler m = unsafeEff $ \es -> do
   les <- forkEnv es
-  (`unEff` es) $ runHandler (HandlerA les handler) m
+  (`unEff` es) $ runHandler (DynamicEffect les handler) m
 
 -- | Interpret an effect using other effects.
 reinterpret
-  :: (EffectStyle e ~ HandlerA)
+  :: (EffectStyle e ~ DynamicEffect)
   => (Eff handlerEs a -> Eff es b)
   -- ^ Introduction of effects encapsulated within the handler.
   -> EffectHandler e handlerEs
@@ -67,7 +67,7 @@ reinterpret
 reinterpret runHandlerEs handler m = unsafeEff $ \es -> do
   les0 <- forkEnv es
   (`unEff` les0) . runHandlerEs . unsafeEff $ \les -> do
-    (`unEff` es) $ runHandler (HandlerA les handler) m
+    (`unEff` es) $ runHandler (DynamicEffect les handler) m
 
 ----------------------------------------
 -- Unlifts

--- a/effectful-core/src/Effectful/Dispatch/Dynamic.hs
+++ b/effectful-core/src/Effectful/Dispatch/Dynamic.hs
@@ -4,7 +4,7 @@ module Effectful.Dispatch.Dynamic
   , EffectStyle
 
   -- * Handling effects
-  , EffectHandler
+  , DynamicEffectHandler
   , DynamicEffect(..)
   , runDynamic
   , rerunDynamic
@@ -63,7 +63,7 @@ rerunDynamic inF f = reinterpretDynamic inF (const f)
 -- | Interpret an effect.
 interpretDynamic
   :: (EffectStyle e ~ DynamicEffect)
-  => EffectHandler e es
+  => DynamicEffectHandler e es
   -- ^ The effect handler.
   -> Eff (e : es) a
   -> Eff      es  a
@@ -76,7 +76,7 @@ reinterpretDynamic
   :: (EffectStyle e ~ DynamicEffect)
   => (Eff handlerEs a -> Eff es b)
   -- ^ Introduction of effects encapsulated within the handler.
-  -> EffectHandler e handlerEs
+  -> DynamicEffectHandler e handlerEs
   -- ^ The effect handler.
   -> Eff (e : es) a
   -> Eff      es  b

--- a/effectful-core/src/Effectful/Dispatch/Dynamic.hs
+++ b/effectful-core/src/Effectful/Dispatch/Dynamic.hs
@@ -1,9 +1,11 @@
 module Effectful.Dispatch.Dynamic
   ( -- * Sending operations to the handler
     send
+  , EffectStyle
 
   -- * Handling effects
   , EffectHandler
+  , HandlerA(..)
   , interpret
   , reinterpret
 
@@ -44,7 +46,8 @@ import Effectful.Internal.Monad
 
 -- | Interpret an effect.
 interpret
-  :: EffectHandler e es
+  :: (EffectStyle e ~ HandlerA)
+  => EffectHandler e es
   -- ^ The effect handler.
   -> Eff (e : es) a
   -> Eff      es  a
@@ -54,7 +57,8 @@ interpret handler m = unsafeEff $ \es -> do
 
 -- | Interpret an effect using other effects.
 reinterpret
-  :: (Eff handlerEs a -> Eff es b)
+  :: (EffectStyle e ~ HandlerA)
+  => (Eff handlerEs a -> Eff es b)
   -- ^ Introduction of effects encapsulated within the handler.
   -> EffectHandler e handlerEs
   -- ^ The effect handler.

--- a/effectful-core/src/Effectful/Dispatch/Static.hs
+++ b/effectful-core/src/Effectful/Dispatch/Static.hs
@@ -4,16 +4,16 @@ module Effectful.Dispatch.Static
   , EffectStyle
 
     -- ** Extending the environment
-  , runData
-  , evalData
-  , execData
+  , runStatic
+  , evalStatic
+  , execStatic
 
     -- ** Data retrieval and update
-  , getData
-  , putData
-  , stateData
-  , stateDataM
-  , localData
+  , getStatic
+  , putStatic
+  , stateStatic
+  , stateStaticM
+  , localStatic
 
     -- ** Unlifts
   , seqUnliftIO

--- a/effectful-core/src/Effectful/Dispatch/Static.hs
+++ b/effectful-core/src/Effectful/Dispatch/Static.hs
@@ -1,6 +1,7 @@
 module Effectful.Dispatch.Static
   ( -- * Low level API
     DataA(..)
+  , EffectStyle
 
     -- ** Extending the environment
   , runData

--- a/effectful-core/src/Effectful/Dispatch/Static.hs
+++ b/effectful-core/src/Effectful/Dispatch/Static.hs
@@ -8,7 +8,7 @@ module Effectful.Dispatch.Static
   , evalStatic
   , execStatic
 
-    -- ** Data retrieval and update
+    -- ** Static retrieval and update
   , getStatic
   , putStatic
   , stateStatic

--- a/effectful-core/src/Effectful/Dispatch/Static.hs
+++ b/effectful-core/src/Effectful/Dispatch/Static.hs
@@ -1,6 +1,6 @@
 module Effectful.Dispatch.Static
   ( -- * Low level API
-    DataA(..)
+    StaticEffect(..)
   , EffectStyle
 
     -- ** Extending the environment

--- a/effectful-core/src/Effectful/Error.hs
+++ b/effectful-core/src/Effectful/Error.hs
@@ -94,6 +94,8 @@ import Effectful.Monad
 newtype Error e :: Effect where
   Error :: ErrorId -> Error e m r
 
+type instance EffectStyle (Error e) = DataA
+
 -- | Handle errors of type @e@.
 runError
   :: forall e es a. Typeable e

--- a/effectful-core/src/Effectful/Error/Dynamic.hs
+++ b/effectful-core/src/Effectful/Error/Dynamic.hs
@@ -22,7 +22,7 @@ runError
   :: Typeable e
   => Eff (Error e : es) a
   -> Eff es (Either (E.CallStack, e) a)
-runError = reinterpret E.runError $ \env -> \case
+runError = reinterpretDynamic E.runError $ \env -> \case
   ThrowError e   -> E.throwError e
   CatchError m h -> localSeqUnlift env $ \unlift -> do
     E.catchError (unlift m) (\cs -> unlift . h cs)

--- a/effectful-core/src/Effectful/Error/Dynamic.hs
+++ b/effectful-core/src/Effectful/Error/Dynamic.hs
@@ -16,7 +16,7 @@ data Error e :: Effect where
   ThrowError :: e -> Error e m a
   CatchError :: m a -> (E.CallStack -> e -> m a) -> Error e m a
 
-type instance EffectStyle (Error e) = HandlerA
+type instance EffectStyle (Error e) = DynamicEffect
 
 runError
   :: Typeable e

--- a/effectful-core/src/Effectful/Error/Dynamic.hs
+++ b/effectful-core/src/Effectful/Error/Dynamic.hs
@@ -16,6 +16,8 @@ data Error e :: Effect where
   ThrowError :: e -> Error e m a
   CatchError :: m a -> (E.CallStack -> e -> m a) -> Error e m a
 
+type instance EffectStyle (Error e) = HandlerA
+
 runError
   :: Typeable e
   => Eff (Error e : es) a

--- a/effectful-core/src/Effectful/Fail.hs
+++ b/effectful-core/src/Effectful/Fail.hs
@@ -10,7 +10,7 @@ import Effectful.Internal.Monad
 
 -- | Run the 'Fail' effect via 'Error'.
 runFail :: Eff (Fail : es) a -> Eff es (Either String a)
-runFail = reinterpret eff $ \_ -> \case
+runFail = rerunDynamic eff $ \case
   Fail msg -> throwError msg
   where
     eff = fmap (either (Left . snd) Right) . runError

--- a/effectful-core/src/Effectful/Internal/Monad.hs
+++ b/effectful-core/src/Effectful/Internal/Monad.hs
@@ -43,7 +43,7 @@ module Effectful.Internal.Monad
   , EffectStyle
 
   -- ** Dynamic dispatch
-  , EffectHandler
+  , DynamicEffectHandler
   , LocalEnv(..)
   , DynamicEffect(..)
   , runHandler
@@ -324,7 +324,7 @@ type role LocalEnv nominal nominal
 newtype LocalEnv (localEs :: [Effect]) (handlerEs :: [Effect]) = LocalEnv (Env localEs)
 
 -- | Type signature of the effect handler.
-type EffectHandler e es
+type DynamicEffectHandler e es
   = forall a localEs. HasCallStack
   => LocalEnv localEs es
   -- ^ Capture of the local environment for handling local 'Eff' computations
@@ -337,7 +337,7 @@ type EffectHandler e es
 --
 -- Represents the effect handler bundled with its environment.
 data DynamicEffect :: Effect -> Type where
-  DynamicEffect :: !(Env es) -> !(EffectHandler e es) -> DynamicEffect e
+  DynamicEffect :: !(Env es) -> !(DynamicEffectHandler e es) -> DynamicEffect e
 
 -- | Run a dynamically dispatched effect with the given handler.
 runHandler

--- a/effectful-core/src/Effectful/Reader.hs
+++ b/effectful-core/src/Effectful/Reader.hs
@@ -15,6 +15,8 @@ import Effectful.Monad
 newtype Reader r :: Effect where
   Reader :: r -> Reader r m a
 
+type instance EffectStyle (Reader r) = DataA
+
 -- | Run a 'Reader' effect with the given initial environment.
 runReader
   :: r -- ^ An initial environment.

--- a/effectful-core/src/Effectful/Reader.hs
+++ b/effectful-core/src/Effectful/Reader.hs
@@ -22,7 +22,7 @@ runReader
   :: r -- ^ An initial environment.
   -> Eff (Reader r : es) a
   -> Eff es a
-runReader r = evalData (StaticEffect (Reader r))
+runReader r = evalData (Reader r)
 
 -- | Fetch the value of the environment.
 ask :: Reader r :> es => Eff es r

--- a/effectful-core/src/Effectful/Reader.hs
+++ b/effectful-core/src/Effectful/Reader.hs
@@ -22,12 +22,12 @@ runReader
   :: r -- ^ An initial environment.
   -> Eff (Reader r : es) a
   -> Eff es a
-runReader r = evalData (Reader r)
+runReader r = evalStatic (Reader r)
 
 -- | Fetch the value of the environment.
 ask :: Reader r :> es => Eff es r
 ask = do
-  StaticEffect (Reader r) <- getData
+  StaticEffect (Reader r) <- getStatic
   pure r
 
 -- | Retrieve a function of the current environment.
@@ -48,4 +48,4 @@ local
   => (r -> r) -- ^ The function to modify the environment.
   -> Eff es a
   -> Eff es a
-local f = localData $ \(StaticEffect (Reader r)) -> StaticEffect (Reader (f r))
+local f = localStatic $ \(StaticEffect (Reader r)) -> StaticEffect (Reader (f r))

--- a/effectful-core/src/Effectful/Reader.hs
+++ b/effectful-core/src/Effectful/Reader.hs
@@ -15,19 +15,19 @@ import Effectful.Monad
 newtype Reader r :: Effect where
   Reader :: r -> Reader r m a
 
-type instance EffectStyle (Reader r) = DataA
+type instance EffectStyle (Reader r) = StaticEffect
 
 -- | Run a 'Reader' effect with the given initial environment.
 runReader
   :: r -- ^ An initial environment.
   -> Eff (Reader r : es) a
   -> Eff es a
-runReader r = evalData (DataA (Reader r))
+runReader r = evalData (StaticEffect (Reader r))
 
 -- | Fetch the value of the environment.
 ask :: Reader r :> es => Eff es r
 ask = do
-  DataA (Reader r) <- getData
+  StaticEffect (Reader r) <- getData
   pure r
 
 -- | Retrieve a function of the current environment.
@@ -48,4 +48,4 @@ local
   => (r -> r) -- ^ The function to modify the environment.
   -> Eff es a
   -> Eff es a
-local f = localData $ \(DataA (Reader r)) -> DataA (Reader (f r))
+local f = localData $ \(StaticEffect (Reader r)) -> StaticEffect (Reader (f r))

--- a/effectful-core/src/Effectful/Reader/Dynamic.hs
+++ b/effectful-core/src/Effectful/Reader/Dynamic.hs
@@ -17,7 +17,7 @@ data Reader r :: Effect where
 type instance EffectStyle (Reader r) = DynamicEffect
 
 runReader :: r -> Eff (Reader r : es) a -> Eff es a
-runReader r = reinterpret (R.runReader r) $ \env -> \case
+runReader r = reinterpretDynamic (R.runReader r) $ \env -> \case
   Ask       -> R.ask
   Local f m -> localSeqUnlift env $ \unlift -> R.local f (unlift m)
 

--- a/effectful-core/src/Effectful/Reader/Dynamic.hs
+++ b/effectful-core/src/Effectful/Reader/Dynamic.hs
@@ -14,7 +14,7 @@ data Reader r :: Effect where
   Ask   :: Reader r m r
   Local :: (r -> r) -> m a -> Reader r m a
 
-type instance EffectStyle (Reader r) = HandlerA
+type instance EffectStyle (Reader r) = DynamicEffect
 
 runReader :: r -> Eff (Reader r : es) a -> Eff es a
 runReader r = reinterpret (R.runReader r) $ \env -> \case

--- a/effectful-core/src/Effectful/Reader/Dynamic.hs
+++ b/effectful-core/src/Effectful/Reader/Dynamic.hs
@@ -14,6 +14,8 @@ data Reader r :: Effect where
   Ask   :: Reader r m r
   Local :: (r -> r) -> m a -> Reader r m a
 
+type instance EffectStyle (Reader r) = HandlerA
+
 runReader :: r -> Eff (Reader r : es) a -> Eff es a
 runReader r = reinterpret (R.runReader r) $ \env -> \case
   Ask       -> R.ask

--- a/effectful-core/src/Effectful/State/Dynamic.hs
+++ b/effectful-core/src/Effectful/State/Dynamic.hs
@@ -34,7 +34,7 @@ data State s :: Effect where
   State  :: (s ->   (a, s)) -> State s m a
   StateM :: (s -> m (a, s)) -> State s m a
 
-type instance EffectStyle (State s) = HandlerA
+type instance EffectStyle (State s) = DynamicEffect
 
 ----------------------------------------
 -- Local

--- a/effectful-core/src/Effectful/State/Dynamic.hs
+++ b/effectful-core/src/Effectful/State/Dynamic.hs
@@ -40,13 +40,13 @@ type instance EffectStyle (State s) = DynamicEffect
 -- Local
 
 runLocalState :: s -> Eff (State s : es) a -> Eff es (a, s)
-runLocalState s0 = reinterpret (L.runState s0) localState
+runLocalState s0 = reinterpretDynamic (L.runState s0) localState
 
 evalLocalState :: s -> Eff (State s : es) a -> Eff es a
-evalLocalState s0 = reinterpret (L.evalState s0) localState
+evalLocalState s0 = reinterpretDynamic (L.evalState s0) localState
 
 execLocalState :: s -> Eff (State s : es) a -> Eff es s
-execLocalState s0 = reinterpret (L.execState s0) localState
+execLocalState s0 = reinterpretDynamic (L.execState s0) localState
 
 localState
   :: L.State s :> es
@@ -63,13 +63,13 @@ localState env = \case
 -- Shared
 
 runSharedState :: s -> Eff (State s : es) a -> Eff es (a, s)
-runSharedState s0 = reinterpret (S.runState s0) sharedState
+runSharedState s0 = reinterpretDynamic (S.runState s0) sharedState
 
 evalSharedState :: s -> Eff (State s : es) a -> Eff es a
-evalSharedState s0 = reinterpret (S.evalState s0) sharedState
+evalSharedState s0 = reinterpretDynamic (S.evalState s0) sharedState
 
 execSharedState :: s -> Eff (State s : es) a -> Eff es s
-execSharedState s0 = reinterpret (S.execState s0) sharedState
+execSharedState s0 = reinterpretDynamic (S.execState s0) sharedState
 
 sharedState
   :: S.State s :> es

--- a/effectful-core/src/Effectful/State/Dynamic.hs
+++ b/effectful-core/src/Effectful/State/Dynamic.hs
@@ -34,6 +34,8 @@ data State s :: Effect where
   State  :: (s ->   (a, s)) -> State s m a
   StateM :: (s -> m (a, s)) -> State s m a
 
+type instance EffectStyle (State s) = HandlerA
+
 ----------------------------------------
 -- Local
 

--- a/effectful-core/src/Effectful/State/Local.hs
+++ b/effectful-core/src/Effectful/State/Local.hs
@@ -54,7 +54,7 @@ runState
   -> Eff (State s : es) a
   -> Eff es (a, s)
 runState s0 m = do
-  (a, StaticEffect (State s)) <- runData (State s0) m
+  (a, State s) <- runStatic (State s0) m
   pure (a, s)
 
 -- | Run a 'State' effect with the given initial state and return the final
@@ -63,7 +63,7 @@ evalState
   :: s -- ^ An initial state.
   -> Eff (State s : es) a
   -> Eff es a -- ^ A return value.
-evalState s = evalData (State s)
+evalState s = evalStatic (State s)
 
 -- | Run a 'State' effect with the given initial state and return the final
 -- state, discarding the final value.
@@ -72,13 +72,13 @@ execState
   -> Eff (State s : es) a
   -> Eff es s
 execState s0 m = do
-  StaticEffect (State s) <- execData (StaticEffect (State s0)) m
+  State s <- execStatic (State s0) m
   pure s
 
 -- | Fetch the current value of the state.
 get :: State s :> es => Eff es s
 get = do
-  StaticEffect (State s) <- getData
+  StaticEffect (State s) <- getStatic
   pure s
 
 -- | Get a function of the current state.
@@ -92,14 +92,14 @@ gets f = f <$> get
 
 -- | Set the current state to the given value.
 put :: State s :> es => s -> Eff es ()
-put s = putData (StaticEffect (State s))
+put s = putStatic (StaticEffect (State s))
 
 -- | Apply the function to the current state and return a value.
 state
   :: State s :> es
   => (s -> (a, s)) -- ^ The function to modify the state.
   -> Eff es a
-state f = stateData $ \(StaticEffect (State s0)) -> let (a, s) = f s0 in (a, StaticEffect (State s))
+state f = stateStatic $ \(StaticEffect (State s0)) -> let (a, s) = f s0 in (a, StaticEffect (State s))
 
 -- | Apply the function to the current state.
 --
@@ -115,7 +115,7 @@ stateM
   :: State s :> es
   => (s -> Eff es (a, s)) -- ^ The function to modify the state.
   -> Eff es a
-stateM f = stateDataM $ \(StaticEffect (State s0)) -> do
+stateM f = stateStaticM $ \(StaticEffect (State s0)) -> do
   (a, s) <- f s0
   pure (a, StaticEffect (State s))
 

--- a/effectful-core/src/Effectful/State/Local.hs
+++ b/effectful-core/src/Effectful/State/Local.hs
@@ -54,7 +54,7 @@ runState
   -> Eff (State s : es) a
   -> Eff es (a, s)
 runState s0 m = do
-  (a, StaticEffect (State s)) <- runData (StaticEffect (State s0)) m
+  (a, StaticEffect (State s)) <- runData (State s0) m
   pure (a, s)
 
 -- | Run a 'State' effect with the given initial state and return the final
@@ -63,7 +63,7 @@ evalState
   :: s -- ^ An initial state.
   -> Eff (State s : es) a
   -> Eff es a -- ^ A return value.
-evalState s = evalData (StaticEffect (State s))
+evalState s = evalData (State s)
 
 -- | Run a 'State' effect with the given initial state and return the final
 -- state, discarding the final value.

--- a/effectful-core/src/Effectful/State/Local.hs
+++ b/effectful-core/src/Effectful/State/Local.hs
@@ -45,7 +45,7 @@ import Effectful.Monad
 newtype State s :: Effect where
   State :: s -> State s m r
 
-type instance EffectStyle (State s) = DataA
+type instance EffectStyle (State s) = StaticEffect
 
 -- | Run a 'State' effect with the given initial state and return the final
 -- value along with the final state.
@@ -54,7 +54,7 @@ runState
   -> Eff (State s : es) a
   -> Eff es (a, s)
 runState s0 m = do
-  (a, DataA (State s)) <- runData (DataA (State s0)) m
+  (a, StaticEffect (State s)) <- runData (StaticEffect (State s0)) m
   pure (a, s)
 
 -- | Run a 'State' effect with the given initial state and return the final
@@ -63,7 +63,7 @@ evalState
   :: s -- ^ An initial state.
   -> Eff (State s : es) a
   -> Eff es a -- ^ A return value.
-evalState s = evalData (DataA (State s))
+evalState s = evalData (StaticEffect (State s))
 
 -- | Run a 'State' effect with the given initial state and return the final
 -- state, discarding the final value.
@@ -72,13 +72,13 @@ execState
   -> Eff (State s : es) a
   -> Eff es s
 execState s0 m = do
-  DataA (State s) <- execData (DataA (State s0)) m
+  StaticEffect (State s) <- execData (StaticEffect (State s0)) m
   pure s
 
 -- | Fetch the current value of the state.
 get :: State s :> es => Eff es s
 get = do
-  DataA (State s) <- getData
+  StaticEffect (State s) <- getData
   pure s
 
 -- | Get a function of the current state.
@@ -92,14 +92,14 @@ gets f = f <$> get
 
 -- | Set the current state to the given value.
 put :: State s :> es => s -> Eff es ()
-put s = putData (DataA (State s))
+put s = putData (StaticEffect (State s))
 
 -- | Apply the function to the current state and return a value.
 state
   :: State s :> es
   => (s -> (a, s)) -- ^ The function to modify the state.
   -> Eff es a
-state f = stateData $ \(DataA (State s0)) -> let (a, s) = f s0 in (a, DataA (State s))
+state f = stateData $ \(StaticEffect (State s0)) -> let (a, s) = f s0 in (a, StaticEffect (State s))
 
 -- | Apply the function to the current state.
 --
@@ -115,9 +115,9 @@ stateM
   :: State s :> es
   => (s -> Eff es (a, s)) -- ^ The function to modify the state.
   -> Eff es a
-stateM f = stateDataM $ \(DataA (State s0)) -> do
+stateM f = stateDataM $ \(StaticEffect (State s0)) -> do
   (a, s) <- f s0
-  pure (a, DataA (State s))
+  pure (a, StaticEffect (State s))
 
 -- | Apply the monadic function to the current state.
 --

--- a/effectful-core/src/Effectful/State/Local.hs
+++ b/effectful-core/src/Effectful/State/Local.hs
@@ -45,6 +45,8 @@ import Effectful.Monad
 newtype State s :: Effect where
   State :: s -> State s m r
 
+type instance EffectStyle (State s) = DataA
+
 -- | Run a 'State' effect with the given initial state and return the final
 -- value along with the final state.
 runState

--- a/effectful-core/src/Effectful/State/Shared.hs
+++ b/effectful-core/src/Effectful/State/Shared.hs
@@ -54,7 +54,7 @@ type instance EffectStyle (State s) = StaticEffect
 runState :: s -> Eff (State s : es) a -> Eff es (a, s)
 runState s m = do
   v <- unsafeEff_ $ newMVar s
-  a <- evalData (StaticEffect (State v)) m
+  a <- evalData (State v) m
   (a, ) <$> unsafeEff_ (readMVar v)
 
 -- | Run a 'State' effect with the given initial state and return the final
@@ -62,14 +62,14 @@ runState s m = do
 evalState :: s -> Eff (State s : es) a -> Eff es a
 evalState s m = do
   v <- unsafeEff_ $ newMVar s
-  evalData (StaticEffect (State v)) m
+  evalData (State v) m
 
 -- | Run a 'State' effect with the given initial state and return the final
 -- state, discarding the final value.
 execState :: s -> Eff (State s : es) a -> Eff es s
 execState s m = do
   v <- unsafeEff_ $ newMVar s
-  _ <- evalData (StaticEffect (State v)) m
+  _ <- evalData (State v) m
   unsafeEff_ $ readMVar v
 
 -- | Fetch the current value of the state.

--- a/effectful-core/src/Effectful/State/Shared.hs
+++ b/effectful-core/src/Effectful/State/Shared.hs
@@ -47,6 +47,8 @@ import Effectful.Monad
 newtype State s :: Effect where
   State :: MVar s -> State s m r
 
+type instance EffectStyle (State s) = DataA
+
 -- | Run a 'State' effect with the given initial state and return the final
 -- value along with the final state.
 runState :: s -> Eff (State s : es) a -> Eff es (a, s)

--- a/effectful-core/src/Effectful/State/Shared.hs
+++ b/effectful-core/src/Effectful/State/Shared.hs
@@ -54,7 +54,7 @@ type instance EffectStyle (State s) = StaticEffect
 runState :: s -> Eff (State s : es) a -> Eff es (a, s)
 runState s m = do
   v <- unsafeEff_ $ newMVar s
-  a <- evalData (State v) m
+  a <- evalStatic (State v) m
   (a, ) <$> unsafeEff_ (readMVar v)
 
 -- | Run a 'State' effect with the given initial state and return the final
@@ -62,14 +62,14 @@ runState s m = do
 evalState :: s -> Eff (State s : es) a -> Eff es a
 evalState s m = do
   v <- unsafeEff_ $ newMVar s
-  evalData (State v) m
+  evalStatic (State v) m
 
 -- | Run a 'State' effect with the given initial state and return the final
 -- state, discarding the final value.
 execState :: s -> Eff (State s : es) a -> Eff es s
 execState s m = do
   v <- unsafeEff_ $ newMVar s
-  _ <- evalData (State v) m
+  _ <- evalStatic (State v) m
   unsafeEff_ $ readMVar v
 
 -- | Fetch the current value of the state.

--- a/effectful-core/src/Effectful/Writer/Dynamic.hs
+++ b/effectful-core/src/Effectful/Writer/Dynamic.hs
@@ -30,10 +30,10 @@ type instance EffectStyle (Writer w) = DynamicEffect
 -- Local
 
 runLocalWriter :: Monoid w => Eff (Writer w : es) a -> Eff es (a, w)
-runLocalWriter = reinterpret L.runWriter localWriter
+runLocalWriter = reinterpretDynamic L.runWriter localWriter
 
 execLocalWriter :: Monoid w => Eff (Writer w : es) a -> Eff es w
-execLocalWriter = reinterpret L.execWriter localWriter
+execLocalWriter = reinterpretDynamic L.execWriter localWriter
 
 localWriter
   :: (L.Writer w :> es, Monoid w)
@@ -48,10 +48,10 @@ localWriter env = \case
 -- Shared
 
 runSharedWriter :: Monoid w => Eff (Writer w : es) a -> Eff es (a, w)
-runSharedWriter = reinterpret S.runWriter sharedWriter
+runSharedWriter = reinterpretDynamic S.runWriter sharedWriter
 
 execSharedWriter :: Monoid w => Eff (Writer w : es) a -> Eff es w
-execSharedWriter = reinterpret S.execWriter sharedWriter
+execSharedWriter = reinterpretDynamic S.execWriter sharedWriter
 
 sharedWriter
   :: (S.Writer w :> es, Monoid w)

--- a/effectful-core/src/Effectful/Writer/Dynamic.hs
+++ b/effectful-core/src/Effectful/Writer/Dynamic.hs
@@ -24,6 +24,8 @@ data Writer w :: Effect where
   Tell   :: w   -> Writer w m ()
   Listen :: m a -> Writer w m (a, w)
 
+type instance EffectStyle (Writer w) = HandlerA
+
 ----------------------------------------
 -- Local
 

--- a/effectful-core/src/Effectful/Writer/Dynamic.hs
+++ b/effectful-core/src/Effectful/Writer/Dynamic.hs
@@ -24,7 +24,7 @@ data Writer w :: Effect where
   Tell   :: w   -> Writer w m ()
   Listen :: m a -> Writer w m (a, w)
 
-type instance EffectStyle (Writer w) = HandlerA
+type instance EffectStyle (Writer w) = DynamicEffect
 
 ----------------------------------------
 -- Local

--- a/effectful-core/src/Effectful/Writer/Local.hs
+++ b/effectful-core/src/Effectful/Writer/Local.hs
@@ -40,7 +40,7 @@ type instance EffectStyle (Writer w) = StaticEffect
 -- output.
 runWriter :: Monoid w => Eff (Writer w : es) a -> Eff es (a, w)
 runWriter m = do
-  (a, StaticEffect (Writer w)) <- runData (StaticEffect (Writer mempty)) m
+  (a, StaticEffect (Writer w)) <- runData (Writer mempty) m
   pure (a, w)
 
 -- | Run a 'Writer' effect and return the final output, discarding the final

--- a/effectful-core/src/Effectful/Writer/Local.hs
+++ b/effectful-core/src/Effectful/Writer/Local.hs
@@ -40,19 +40,19 @@ type instance EffectStyle (Writer w) = StaticEffect
 -- output.
 runWriter :: Monoid w => Eff (Writer w : es) a -> Eff es (a, w)
 runWriter m = do
-  (a, StaticEffect (Writer w)) <- runData (Writer mempty) m
+  (a, Writer w) <- runStatic (Writer mempty) m
   pure (a, w)
 
 -- | Run a 'Writer' effect and return the final output, discarding the final
 -- value.
 execWriter :: Monoid w => Eff (Writer w : es) a -> Eff es w
 execWriter m = do
-  StaticEffect (Writer w) <- execData (StaticEffect (Writer mempty)) m
+  Writer w <- execStatic (Writer mempty) m
   pure w
 
 -- | Append the given output to the overall output of the 'Writer'.
 tell :: (Writer w :> es, Monoid w) => w -> Eff es ()
-tell w = stateData $ \(StaticEffect (Writer w0)) -> ((), StaticEffect (Writer (w0 <> w)))
+tell w = stateStatic $ \(StaticEffect (Writer w0)) -> ((), StaticEffect (Writer (w0 <> w)))
 
 -- | Execute an action and append its output to the overall output of the
 -- 'Writer'.

--- a/effectful-core/src/Effectful/Writer/Local.hs
+++ b/effectful-core/src/Effectful/Writer/Local.hs
@@ -34,25 +34,25 @@ import Effectful.Monad
 newtype Writer w :: Effect where
   Writer :: w -> Writer w m r
 
-type instance EffectStyle (Writer w) = DataA
+type instance EffectStyle (Writer w) = StaticEffect
 
 -- | Run a 'Writer' effect and return the final value along with the final
 -- output.
 runWriter :: Monoid w => Eff (Writer w : es) a -> Eff es (a, w)
 runWriter m = do
-  (a, DataA (Writer w)) <- runData (DataA (Writer mempty)) m
+  (a, StaticEffect (Writer w)) <- runData (StaticEffect (Writer mempty)) m
   pure (a, w)
 
 -- | Run a 'Writer' effect and return the final output, discarding the final
 -- value.
 execWriter :: Monoid w => Eff (Writer w : es) a -> Eff es w
 execWriter m = do
-  DataA (Writer w) <- execData (DataA (Writer mempty)) m
+  StaticEffect (Writer w) <- execData (StaticEffect (Writer mempty)) m
   pure w
 
 -- | Append the given output to the overall output of the 'Writer'.
 tell :: (Writer w :> es, Monoid w) => w -> Eff es ()
-tell w = stateData $ \(DataA (Writer w0)) -> ((), DataA (Writer (w0 <> w)))
+tell w = stateData $ \(StaticEffect (Writer w0)) -> ((), StaticEffect (Writer (w0 <> w)))
 
 -- | Execute an action and append its output to the overall output of the
 -- 'Writer'.
@@ -73,13 +73,13 @@ tell w = stateData $ \(DataA (Writer w0)) -> ((), DataA (Writer (w0 <> w)))
 -- "Hi there!"
 listen :: (Writer w :> es, Monoid w) => Eff es a -> Eff es (a, w)
 listen m = unsafeEff $ \es -> mask $ \restore -> do
-  w0 <- stateEnv es $ \(DataA (Writer w)) -> (w, DataA (Writer mempty))
+  w0 <- stateEnv es $ \(StaticEffect (Writer w)) -> (w, StaticEffect (Writer mempty))
   a <- restore (unEff m es) `onException` merge es w0
   (a, ) <$> merge es w0
   where
     merge es w0 =
       -- If an exception is thrown, restore w0 and keep parts of w1.
-      stateEnv es $ \(DataA (Writer w1)) -> (w1, DataA (Writer (w0 <> w1)))
+      stateEnv es $ \(StaticEffect (Writer w1)) -> (w1, StaticEffect (Writer (w0 <> w1)))
 
 -- | Execute an action and append its output to the overall output of the
 -- 'Writer', then return the final value along with a function of the recorded

--- a/effectful-core/src/Effectful/Writer/Local.hs
+++ b/effectful-core/src/Effectful/Writer/Local.hs
@@ -34,6 +34,8 @@ import Effectful.Monad
 newtype Writer w :: Effect where
   Writer :: w -> Writer w m r
 
+type instance EffectStyle (Writer w) = DataA
+
 -- | Run a 'Writer' effect and return the final value along with the final
 -- output.
 runWriter :: Monoid w => Eff (Writer w : es) a -> Eff es (a, w)

--- a/effectful-core/src/Effectful/Writer/Shared.hs
+++ b/effectful-core/src/Effectful/Writer/Shared.hs
@@ -34,14 +34,14 @@ import Effectful.Monad
 newtype Writer w :: Effect where
   Writer :: MVar w -> Writer w m r
 
-type instance EffectStyle (Writer w) = DataA
+type instance EffectStyle (Writer w) = StaticEffect
 
 -- | Run a 'Writer' effect and return the final value along with the final
 -- output.
 runWriter :: Monoid w => Eff (Writer w : es) a -> Eff es (a, w)
 runWriter m = do
   v <- unsafeEff_ $ newMVar mempty
-  a <- evalData (DataA (Writer v)) m
+  a <- evalData (StaticEffect (Writer v)) m
   (a, ) <$> unsafeEff_ (readMVar v)
 
 -- | Run a 'Writer' effect and return the final output, discarding the final
@@ -49,13 +49,13 @@ runWriter m = do
 execWriter :: Monoid w => Eff (Writer w : es) a -> Eff es w
 execWriter m = do
   v <- unsafeEff_ $ newMVar mempty
-  _ <- evalData (DataA (Writer v)) m
+  _ <- evalData (StaticEffect (Writer v)) m
   unsafeEff_ $ readMVar v
 
 -- | Append the given output to the overall output of the 'Writer'.
 tell :: (Writer w :> es, Monoid w) => w -> Eff es ()
 tell w1 = unsafeEff $ \es -> do
-  DataA (Writer v) <- getEnv es
+  StaticEffect (Writer v) <- getEnv es
   modifyMVar_ v $ \w0 -> let w = w0 <> w1 in w `seq` pure w
 
 -- | Execute an action and append its output to the overall output of the
@@ -83,14 +83,14 @@ listen m = unsafeEff $ \es -> do
   uninterruptibleMask $ \restore -> do
     v1 <- newMVar mempty
     -- Replace thread local MVar with a fresh one for isolated listening.
-    v0 <- stateEnv es $ \(DataA (Writer v)) -> (v, DataA (Writer v1))
+    v0 <- stateEnv es $ \(StaticEffect (Writer v)) -> (v, StaticEffect (Writer v1))
     a <- restore (unEff m es) `onException` merge es v0 v1
     (a, ) <$> merge es v0 v1
   where
     -- Merge results accumulated in the local MVar with the mainline. If an
     -- exception was received while listening, merge results recorded so far.
     merge es v0 v1 = do
-      putEnv es $ DataA (Writer v0)
+      putEnv es $ StaticEffect (Writer v0)
       w1 <- readMVar v1
       modifyMVar_ v0 $ \w0 -> let w = w0 <> w1 in w `seq` pure w
       pure w1

--- a/effectful-core/src/Effectful/Writer/Shared.hs
+++ b/effectful-core/src/Effectful/Writer/Shared.hs
@@ -34,6 +34,8 @@ import Effectful.Monad
 newtype Writer w :: Effect where
   Writer :: MVar w -> Writer w m r
 
+type instance EffectStyle (Writer w) = DataA
+
 -- | Run a 'Writer' effect and return the final value along with the final
 -- output.
 runWriter :: Monoid w => Eff (Writer w : es) a -> Eff es (a, w)

--- a/effectful-core/src/Effectful/Writer/Shared.hs
+++ b/effectful-core/src/Effectful/Writer/Shared.hs
@@ -41,7 +41,7 @@ type instance EffectStyle (Writer w) = StaticEffect
 runWriter :: Monoid w => Eff (Writer w : es) a -> Eff es (a, w)
 runWriter m = do
   v <- unsafeEff_ $ newMVar mempty
-  a <- evalData (StaticEffect (Writer v)) m
+  a <- evalData (Writer v) m
   (a, ) <$> unsafeEff_ (readMVar v)
 
 -- | Run a 'Writer' effect and return the final output, discarding the final
@@ -49,7 +49,7 @@ runWriter m = do
 execWriter :: Monoid w => Eff (Writer w : es) a -> Eff es w
 execWriter m = do
   v <- unsafeEff_ $ newMVar mempty
-  _ <- evalData (StaticEffect (Writer v)) m
+  _ <- evalData (Writer v) m
   unsafeEff_ $ readMVar v
 
 -- | Append the given output to the overall output of the 'Writer'.

--- a/effectful-core/src/Effectful/Writer/Shared.hs
+++ b/effectful-core/src/Effectful/Writer/Shared.hs
@@ -41,7 +41,7 @@ type instance EffectStyle (Writer w) = StaticEffect
 runWriter :: Monoid w => Eff (Writer w : es) a -> Eff es (a, w)
 runWriter m = do
   v <- unsafeEff_ $ newMVar mempty
-  a <- evalData (Writer v) m
+  a <- evalStatic (Writer v) m
   (a, ) <$> unsafeEff_ (readMVar v)
 
 -- | Run a 'Writer' effect and return the final output, discarding the final
@@ -49,7 +49,7 @@ runWriter m = do
 execWriter :: Monoid w => Eff (Writer w : es) a -> Eff es w
 execWriter m = do
   v <- unsafeEff_ $ newMVar mempty
-  _ <- evalData (Writer v) m
+  _ <- evalStatic (Writer v) m
   unsafeEff_ $ readMVar v
 
 -- | Append the given output to the overall output of the 'Writer'.

--- a/effectful/bench/Concurrency.hs
+++ b/effectful/bench/Concurrency.hs
@@ -61,28 +61,28 @@ type instance EffectStyle Fork = DynamicEffect
 
 -- | Uses 'localUnliftIO' and 'withLiftMapIO'.
 runFork1 :: IOE :> es => Eff (Fork : es) a -> Eff es a
-runFork1 = interpret $ \env -> \case
+runFork1 = interpretDynamic $ \env -> \case
   ForkWithUnmask m -> withLiftMapIO env $ \liftMap -> do
     localUnliftIO env (ConcUnlift Ephemeral $ Limited 1) $ \unlift -> do
       asyncWithUnmask $ \unmask -> unlift $ m $ liftMap unmask
 
 -- | Uses 'localUnlift' and 'withLiftMap'.
 runFork2 :: IOE :> es => Eff (Fork : es) a -> Eff es a
-runFork2 = reinterpret A.runConcurrent $ \env -> \case
+runFork2 = reinterpretDynamic A.runConcurrent $ \env -> \case
   ForkWithUnmask m -> withLiftMap env $ \liftMap -> do
     localUnlift env (ConcUnlift Ephemeral $ Limited 1) $ \unlift -> do
       A.asyncWithUnmask $ \unmask -> unlift $ m $ liftMap unmask
 
 -- | Uses 'localLiftUnliftIO'.
 runFork3 :: IOE :> es => Eff (Fork : es) a -> Eff es a
-runFork3 = interpret $ \env -> \case
+runFork3 = interpretDynamic $ \env -> \case
   ForkWithUnmask m -> do
     localLiftUnliftIO env (ConcUnlift Persistent $ Limited 1) $ \lift unlift -> do
       asyncWithUnmask $ \unmask -> unlift $ m $ lift . unmask . unlift
 
 -- | Uses 'localLiftUnlift'.
 runFork4 :: IOE :> es => Eff (Fork : es) a -> Eff es a
-runFork4 = reinterpret A.runConcurrent $ \env -> \case
+runFork4 = reinterpretDynamic A.runConcurrent $ \env -> \case
   ForkWithUnmask m -> do
     localLiftUnlift env (ConcUnlift Persistent $ Limited 1) $ \lift unlift -> do
       A.asyncWithUnmask $ \unmask -> unlift $ m $ lift . unmask . unlift

--- a/effectful/bench/Concurrency.hs
+++ b/effectful/bench/Concurrency.hs
@@ -57,6 +57,8 @@ op = pure 1
 data Fork :: Effect where
   ForkWithUnmask :: ((forall a. m a -> m a) -> m r) -> Fork m (Async r)
 
+type instance EffectStyle Fork = DynamicEffect
+
 -- | Uses 'localUnliftIO' and 'withLiftMapIO'.
 runFork1 :: IOE :> es => Eff (Fork : es) a -> Eff es a
 runFork1 = interpret $ \env -> \case

--- a/effectful/bench/FileSizes.hs
+++ b/effectful/bench/FileSizes.hs
@@ -77,6 +77,9 @@ ref_calculateFileSizes files = do
 data Effectful_File :: E.Effect where
   Effectful_tryFileSize :: FilePath -> Effectful_File m (Maybe Int)
 
+type instance E.EffectStyle Effectful_File = E.DynamicEffect
+
+
 effectful_tryFileSize :: Effectful_File E.:> es => FilePath -> E.Eff es (Maybe Int)
 effectful_tryFileSize = E.send . Effectful_tryFileSize
 
@@ -86,6 +89,8 @@ effectful_runFile = E.interpret \_ -> \case
 
 data Effectful_Logging :: E.Effect where
   Effectful_logMsg :: String -> Effectful_Logging m ()
+
+type instance E.EffectStyle Effectful_Logging = E.DynamicEffect
 
 effectful_logMsg :: Effectful_Logging E.:> es => String -> E.Eff es ()
 effectful_logMsg = E.send . Effectful_logMsg

--- a/effectful/bench/FileSizes.hs
+++ b/effectful/bench/FileSizes.hs
@@ -217,7 +217,7 @@ fs_tryFileSize :: FS.Member FS_File es => FilePath -> FS.Eff es (Maybe Int)
 fs_tryFileSize = FS.send . FS_tryFileSize
 
 fs_runFile :: FS.LastMember IO es => FS.Eff (FS_File : es) a -> FS.Eff es a
-fs_runFile = FS.interpretDynamic \case
+fs_runFile = FS.interpret \case
   FS_tryFileSize path -> liftIO $ tryGetFileSize path
 
 data FS_Logging r where
@@ -229,7 +229,7 @@ fs_logMsg = FS.send . FS_logMsg
 fs_runLogging
   :: FS.Eff (FS_Logging : es) a
   -> FS.Eff es (a, [String])
-fs_runLogging = FS.runState [] . FS.reinterpretDynamic \case
+fs_runLogging = FS.runState [] . FS.reinterpret \case
   FS_logMsg msg -> FS.modify (msg :)
 
 ----------
@@ -354,7 +354,7 @@ poly_tryFileSize :: P.Member Poly_File es => FilePath -> P.Sem es (Maybe Int)
 poly_tryFileSize = P.send . Poly_tryFileSize
 
 poly_runFile :: P.Member (P.Embed IO) es => P.Sem (Poly_File : es) a -> P.Sem es a
-poly_runFile = P.interpretDynamic \case
+poly_runFile = P.interpret \case
   Poly_tryFileSize path -> P.embed $ tryGetFileSize path
 
 data Poly_Logging :: E.Effect where
@@ -364,7 +364,7 @@ poly_logMsg :: P.Member Poly_Logging es => String -> P.Sem es ()
 poly_logMsg = P.send . Poly_logMsg
 
 poly_runLogging :: P.Sem (Poly_Logging : es) a -> P.Sem es (a, [String])
-poly_runLogging = fmap poly_swap . P.runState [] . P.reinterpretDynamic \case
+poly_runLogging = fmap poly_swap . P.runState [] . P.reinterpret \case
   Poly_logMsg msg -> P.modify (msg :)
 
 poly_swap :: (a, b) -> (b, a)

--- a/effectful/examples/FileSystem.hs
+++ b/effectful/examples/FileSystem.hs
@@ -22,6 +22,8 @@ data FileSystem :: Effect where
   ReadFile  :: FilePath -> FileSystem m String
   WriteFile :: FilePath -> String -> FileSystem m ()
 
+type instance EffectStyle FileSystem = DynamicEffect
+
 --- | File system error.
 newtype FsError = FsError String
 

--- a/effectful/examples/FileSystem.hs
+++ b/effectful/examples/FileSystem.hs
@@ -45,7 +45,7 @@ runFileSystemIO
   :: (IOE :> es, Error FsError :> es)
   => Eff (FileSystem : es) a
   -> Eff es a
-runFileSystemIO = interpret $ \_ -> \case
+runFileSystemIO = runDynamic $ \case
   ReadFile path           -> adapt $ IO.readFile path
   WriteFile path contents -> adapt $ IO.writeFile path contents
   where
@@ -56,7 +56,7 @@ runFileSystemPure
   => M.Map FilePath String
   -> Eff (FileSystem : es) a
   -> Eff es a
-runFileSystemPure fs0 = reinterpret (evalState fs0) $ \_ -> \case
+runFileSystemPure fs0 = rerunDynamic (evalState fs0) $ \case
   ReadFile path -> gets (M.lookup path) >>= \case
     Just contents -> pure contents
     Nothing       -> throwError . FsError $ "File not found: " ++ show path

--- a/effectful/src/Effectful/Concurrent/Effect.hs
+++ b/effectful/src/Effectful/Concurrent/Effect.hs
@@ -70,6 +70,8 @@ import Effectful.Monad
 data Concurrent :: Effect where
   Concurrent :: Concurrent m r
 
+type instance EffectStyle Concurrent = DataA
+
 -- | Run the 'Concurrent' effect.
 runConcurrent :: IOE :> es => Eff (Concurrent : es) a -> Eff es a
 runConcurrent = evalData (DataA Concurrent)

--- a/effectful/src/Effectful/Concurrent/Effect.hs
+++ b/effectful/src/Effectful/Concurrent/Effect.hs
@@ -74,7 +74,7 @@ type instance EffectStyle Concurrent = StaticEffect
 
 -- | Run the 'Concurrent' effect.
 runConcurrent :: IOE :> es => Eff (Concurrent : es) a -> Eff es a
-runConcurrent = evalData Concurrent
+runConcurrent = evalStatic Concurrent
 
 -- $setup
 -- >>> import Effectful.Concurrent

--- a/effectful/src/Effectful/Concurrent/Effect.hs
+++ b/effectful/src/Effectful/Concurrent/Effect.hs
@@ -70,11 +70,11 @@ import Effectful.Monad
 data Concurrent :: Effect where
   Concurrent :: Concurrent m r
 
-type instance EffectStyle Concurrent = DataA
+type instance EffectStyle Concurrent = StaticEffect
 
 -- | Run the 'Concurrent' effect.
 runConcurrent :: IOE :> es => Eff (Concurrent : es) a -> Eff es a
-runConcurrent = evalData (DataA Concurrent)
+runConcurrent = evalData (StaticEffect Concurrent)
 
 -- $setup
 -- >>> import Effectful.Concurrent

--- a/effectful/src/Effectful/Concurrent/Effect.hs
+++ b/effectful/src/Effectful/Concurrent/Effect.hs
@@ -74,7 +74,7 @@ type instance EffectStyle Concurrent = StaticEffect
 
 -- | Run the 'Concurrent' effect.
 runConcurrent :: IOE :> es => Eff (Concurrent : es) a -> Eff es a
-runConcurrent = evalData (StaticEffect Concurrent)
+runConcurrent = evalData Concurrent
 
 -- $setup
 -- >>> import Effectful.Concurrent

--- a/effectful/src/Effectful/Environment.hs
+++ b/effectful/src/Effectful/Environment.hs
@@ -26,6 +26,8 @@ import Effectful.Monad
 data Environment :: Effect where
   Environment :: Environment m r
 
+type instance EffectStyle Environment = DataA
+
 -- | Run the 'Environment' effect.
 runEnvironment :: IOE :> es => Eff (Environment : es) a -> Eff es a
 runEnvironment = evalData (DataA Environment)

--- a/effectful/src/Effectful/Environment.hs
+++ b/effectful/src/Effectful/Environment.hs
@@ -30,7 +30,7 @@ type instance EffectStyle Environment = StaticEffect
 
 -- | Run the 'Environment' effect.
 runEnvironment :: IOE :> es => Eff (Environment : es) a -> Eff es a
-runEnvironment = evalData (StaticEffect Environment)
+runEnvironment = evalData Environment
 
 -- | Lifted 'E.getArgs'.
 getArgs :: Environment :> es => Eff es [String]

--- a/effectful/src/Effectful/Environment.hs
+++ b/effectful/src/Effectful/Environment.hs
@@ -26,11 +26,11 @@ import Effectful.Monad
 data Environment :: Effect where
   Environment :: Environment m r
 
-type instance EffectStyle Environment = DataA
+type instance EffectStyle Environment = StaticEffect
 
 -- | Run the 'Environment' effect.
 runEnvironment :: IOE :> es => Eff (Environment : es) a -> Eff es a
-runEnvironment = evalData (DataA Environment)
+runEnvironment = evalData (StaticEffect Environment)
 
 -- | Lifted 'E.getArgs'.
 getArgs :: Environment :> es => Eff es [String]

--- a/effectful/src/Effectful/Environment.hs
+++ b/effectful/src/Effectful/Environment.hs
@@ -30,7 +30,7 @@ type instance EffectStyle Environment = StaticEffect
 
 -- | Run the 'Environment' effect.
 runEnvironment :: IOE :> es => Eff (Environment : es) a -> Eff es a
-runEnvironment = evalData Environment
+runEnvironment = evalStatic Environment
 
 -- | Lifted 'E.getArgs'.
 getArgs :: Environment :> es => Eff es [String]

--- a/effectful/src/Effectful/FileSystem.hs
+++ b/effectful/src/Effectful/FileSystem.hs
@@ -98,6 +98,8 @@ import Effectful.Monad
 data FileSystem :: Effect where
   FileSystem :: FileSystem m r
 
+type instance EffectStyle FileSystem = DataA
+
 -- | Run the 'FileSystem' effect.
 runFileSystem :: IOE :> es => Eff (FileSystem : es) a -> Eff es a
 runFileSystem = evalData (DataA FileSystem)

--- a/effectful/src/Effectful/FileSystem.hs
+++ b/effectful/src/Effectful/FileSystem.hs
@@ -102,7 +102,7 @@ type instance EffectStyle FileSystem = StaticEffect
 
 -- | Run the 'FileSystem' effect.
 runFileSystem :: IOE :> es => Eff (FileSystem : es) a -> Eff es a
-runFileSystem = evalData (StaticEffect FileSystem)
+runFileSystem = evalData FileSystem
 
 ----------------------------------------
 -- Actions on directories

--- a/effectful/src/Effectful/FileSystem.hs
+++ b/effectful/src/Effectful/FileSystem.hs
@@ -98,11 +98,11 @@ import Effectful.Monad
 data FileSystem :: Effect where
   FileSystem :: FileSystem m r
 
-type instance EffectStyle FileSystem = DataA
+type instance EffectStyle FileSystem = StaticEffect
 
 -- | Run the 'FileSystem' effect.
 runFileSystem :: IOE :> es => Eff (FileSystem : es) a -> Eff es a
-runFileSystem = evalData (DataA FileSystem)
+runFileSystem = evalData (StaticEffect FileSystem)
 
 ----------------------------------------
 -- Actions on directories

--- a/effectful/src/Effectful/FileSystem.hs
+++ b/effectful/src/Effectful/FileSystem.hs
@@ -102,7 +102,7 @@ type instance EffectStyle FileSystem = StaticEffect
 
 -- | Run the 'FileSystem' effect.
 runFileSystem :: IOE :> es => Eff (FileSystem : es) a -> Eff es a
-runFileSystem = evalData FileSystem
+runFileSystem = evalStatic FileSystem
 
 ----------------------------------------
 -- Actions on directories

--- a/effectful/src/Effectful/FileSystem/Effect.hs
+++ b/effectful/src/Effectful/FileSystem/Effect.hs
@@ -10,6 +10,8 @@ import Effectful.Monad
 data FileSystem :: Effect where
   FileSystem :: FileSystem m r
 
+type instance EffectStyle FileSystem = DataA
+
 -- | Run the 'FileSystem' effect.
 runFileSystem :: IOE :> es => Eff (FileSystem : es) a -> Eff es a
 runFileSystem = evalData (DataA FileSystem)

--- a/effectful/src/Effectful/FileSystem/Effect.hs
+++ b/effectful/src/Effectful/FileSystem/Effect.hs
@@ -10,8 +10,8 @@ import Effectful.Monad
 data FileSystem :: Effect where
   FileSystem :: FileSystem m r
 
-type instance EffectStyle FileSystem = DataA
+type instance EffectStyle FileSystem = StaticEffect
 
 -- | Run the 'FileSystem' effect.
 runFileSystem :: IOE :> es => Eff (FileSystem : es) a -> Eff es a
-runFileSystem = evalData (DataA FileSystem)
+runFileSystem = evalData (StaticEffect FileSystem)

--- a/effectful/src/Effectful/FileSystem/Effect.hs
+++ b/effectful/src/Effectful/FileSystem/Effect.hs
@@ -14,4 +14,4 @@ type instance EffectStyle FileSystem = StaticEffect
 
 -- | Run the 'FileSystem' effect.
 runFileSystem :: IOE :> es => Eff (FileSystem : es) a -> Eff es a
-runFileSystem = evalData (StaticEffect FileSystem)
+runFileSystem = evalData FileSystem

--- a/effectful/src/Effectful/FileSystem/Effect.hs
+++ b/effectful/src/Effectful/FileSystem/Effect.hs
@@ -14,4 +14,4 @@ type instance EffectStyle FileSystem = StaticEffect
 
 -- | Run the 'FileSystem' effect.
 runFileSystem :: IOE :> es => Eff (FileSystem : es) a -> Eff es a
-runFileSystem = evalData FileSystem
+runFileSystem = evalStatic FileSystem

--- a/effectful/src/Effectful/Process.hs
+++ b/effectful/src/Effectful/Process.hs
@@ -57,10 +57,10 @@ import Effectful.Monad
 data Process :: Effect where
   Process :: Process m r
 
-type instance EffectStyle Process = DataA
+type instance EffectStyle Process = StaticEffect
 
 runProcess :: IOE :> es => Eff (Process : es) a -> Eff es a
-runProcess = evalData (DataA Process)
+runProcess = evalData (StaticEffect Process)
 
 ----------------------------------------
 -- Running sub-processes

--- a/effectful/src/Effectful/Process.hs
+++ b/effectful/src/Effectful/Process.hs
@@ -60,7 +60,7 @@ data Process :: Effect where
 type instance EffectStyle Process = StaticEffect
 
 runProcess :: IOE :> es => Eff (Process : es) a -> Eff es a
-runProcess = evalData (StaticEffect Process)
+runProcess = evalData Process
 
 ----------------------------------------
 -- Running sub-processes

--- a/effectful/src/Effectful/Process.hs
+++ b/effectful/src/Effectful/Process.hs
@@ -57,6 +57,8 @@ import Effectful.Monad
 data Process :: Effect where
   Process :: Process m r
 
+type instance EffectStyle Process = DataA
+
 runProcess :: IOE :> es => Eff (Process : es) a -> Eff es a
 runProcess = evalData (DataA Process)
 

--- a/effectful/src/Effectful/Process.hs
+++ b/effectful/src/Effectful/Process.hs
@@ -60,7 +60,7 @@ data Process :: Effect where
 type instance EffectStyle Process = StaticEffect
 
 runProcess :: IOE :> es => Eff (Process : es) a -> Eff es a
-runProcess = evalData Process
+runProcess = evalStatic Process
 
 ----------------------------------------
 -- Running sub-processes

--- a/effectful/src/Effectful/Resource.hs
+++ b/effectful/src/Effectful/Resource.hs
@@ -61,7 +61,7 @@ getInternalState = do
 --
 -- /Note:/ the 'R.InternalState' will not be closed at the end.
 runInternalState :: R.InternalState -> Eff (Resource : es) a -> Eff es a
-runInternalState istate = evalData (StaticEffect (Resource istate))
+runInternalState istate = evalData (Resource istate)
 
 ----------------------------------------
 -- Orphan instance

--- a/effectful/src/Effectful/Resource.hs
+++ b/effectful/src/Effectful/Resource.hs
@@ -54,14 +54,14 @@ runResource m = unsafeEff $ \es0 -> do
 -- | Get the 'R.InternalState' of the current 'Resource' effect.
 getInternalState :: Resource :> es => Eff es R.InternalState
 getInternalState = do
-  StaticEffect (Resource istate) <- getData
+  StaticEffect (Resource istate) <- getStatic
   pure istate
 
 -- | Run the 'Resource' effect with existing 'R.InternalState'.
 --
 -- /Note:/ the 'R.InternalState' will not be closed at the end.
 runInternalState :: R.InternalState -> Eff (Resource : es) a -> Eff es a
-runInternalState istate = evalData (Resource istate)
+runInternalState istate = evalStatic (Resource istate)
 
 ----------------------------------------
 -- Orphan instance

--- a/effectful/src/Effectful/Resource.hs
+++ b/effectful/src/Effectful/Resource.hs
@@ -31,7 +31,7 @@ import Effectful.Monad
 newtype Resource :: Effect where
   Resource :: R.InternalState -> Resource m r
 
-type instance EffectStyle Resource = DataA
+type instance EffectStyle Resource = StaticEffect
 
 -- | Run the resource effect.
 runResource :: IOE :> es => Eff (Resource : es) a -> Eff es a
@@ -39,7 +39,7 @@ runResource m = unsafeEff $ \es0 -> do
   size0 <- sizeEnv es0
   istate <- R.createInternalState
   mask $ \restore -> do
-    es <- unsafeConsEnv (DataA (Resource istate)) noRelinker es0
+    es <- unsafeConsEnv (StaticEffect (Resource istate)) noRelinker es0
     a <- restore (unEff m es) `catch` \e -> do
       unsafeTailEnv size0 es
       RI.stateCleanupChecked (Just e) istate
@@ -54,18 +54,18 @@ runResource m = unsafeEff $ \es0 -> do
 -- | Get the 'R.InternalState' of the current 'Resource' effect.
 getInternalState :: Resource :> es => Eff es R.InternalState
 getInternalState = do
-  DataA (Resource istate) <- getData
+  StaticEffect (Resource istate) <- getData
   pure istate
 
 -- | Run the 'Resource' effect with existing 'R.InternalState'.
 --
 -- /Note:/ the 'R.InternalState' will not be closed at the end.
 runInternalState :: R.InternalState -> Eff (Resource : es) a -> Eff es a
-runInternalState istate = evalData (DataA (Resource istate))
+runInternalState istate = evalData (StaticEffect (Resource istate))
 
 ----------------------------------------
 -- Orphan instance
 
 instance (IOE :> es, Resource :> es) => R.MonadResource (Eff es) where
   liftResourceT (RI.ResourceT m) = unsafeEff $ \es -> do
-    getEnv es >>= \(DataA (Resource istate)) -> m istate
+    getEnv es >>= \(StaticEffect (Resource istate)) -> m istate

--- a/effectful/src/Effectful/Resource.hs
+++ b/effectful/src/Effectful/Resource.hs
@@ -31,6 +31,8 @@ import Effectful.Monad
 newtype Resource :: Effect where
   Resource :: R.InternalState -> Resource m r
 
+type instance EffectStyle Resource = DataA
+
 -- | Run the resource effect.
 runResource :: IOE :> es => Eff (Resource : es) a -> Eff es a
 runResource m = unsafeEff $ \es0 -> do

--- a/effectful/src/Effectful/Temporary.hs
+++ b/effectful/src/Effectful/Temporary.hs
@@ -17,11 +17,11 @@ import Effectful.Monad
 data Temporary :: Effect where
   Temporary :: Temporary m r
 
-type instance EffectStyle Temporary = DataA
+type instance EffectStyle Temporary = StaticEffect
 
 -- | Run the 'Temporary' effect.
 runTemporary :: IOE :> es => Eff (Temporary : es) a -> Eff es a
-runTemporary = evalData (DataA Temporary)
+runTemporary = evalData (StaticEffect Temporary)
 
 -- | Lifted 'T.withSystemTempFile'.
 withSystemTempFile

--- a/effectful/src/Effectful/Temporary.hs
+++ b/effectful/src/Effectful/Temporary.hs
@@ -21,7 +21,7 @@ type instance EffectStyle Temporary = StaticEffect
 
 -- | Run the 'Temporary' effect.
 runTemporary :: IOE :> es => Eff (Temporary : es) a -> Eff es a
-runTemporary = evalData (StaticEffect Temporary)
+runTemporary = evalData Temporary
 
 -- | Lifted 'T.withSystemTempFile'.
 withSystemTempFile

--- a/effectful/src/Effectful/Temporary.hs
+++ b/effectful/src/Effectful/Temporary.hs
@@ -21,7 +21,7 @@ type instance EffectStyle Temporary = StaticEffect
 
 -- | Run the 'Temporary' effect.
 runTemporary :: IOE :> es => Eff (Temporary : es) a -> Eff es a
-runTemporary = evalData Temporary
+runTemporary = evalStatic Temporary
 
 -- | Lifted 'T.withSystemTempFile'.
 withSystemTempFile

--- a/effectful/src/Effectful/Temporary.hs
+++ b/effectful/src/Effectful/Temporary.hs
@@ -17,6 +17,8 @@ import Effectful.Monad
 data Temporary :: Effect where
   Temporary :: Temporary m r
 
+type instance EffectStyle Temporary = DataA
+
 -- | Run the 'Temporary' effect.
 runTemporary :: IOE :> es => Eff (Temporary : es) a -> Eff es a
 runTemporary = evalData (DataA Temporary)

--- a/effectful/src/Effectful/Timeout.hs
+++ b/effectful/src/Effectful/Timeout.hs
@@ -13,6 +13,8 @@ import Effectful.Monad
 data Timeout :: Effect where
   Timeout :: Timeout m r
 
+type instance EffectStyle Timeout = DataA
+
 -- | Run the 'Timeout' effect.
 runTimeout :: IOE :> es => Eff (Timeout : es) a -> Eff es a
 runTimeout = evalData (DataA Timeout)

--- a/effectful/src/Effectful/Timeout.hs
+++ b/effectful/src/Effectful/Timeout.hs
@@ -13,11 +13,11 @@ import Effectful.Monad
 data Timeout :: Effect where
   Timeout :: Timeout m r
 
-type instance EffectStyle Timeout = DataA
+type instance EffectStyle Timeout = StaticEffect
 
 -- | Run the 'Timeout' effect.
 runTimeout :: IOE :> es => Eff (Timeout : es) a -> Eff es a
-runTimeout = evalData (DataA Timeout)
+runTimeout = evalData (StaticEffect Timeout)
 
 -- | Lifted 'T.timeout'.
 timeout

--- a/effectful/src/Effectful/Timeout.hs
+++ b/effectful/src/Effectful/Timeout.hs
@@ -17,7 +17,7 @@ type instance EffectStyle Timeout = StaticEffect
 
 -- | Run the 'Timeout' effect.
 runTimeout :: IOE :> es => Eff (Timeout : es) a -> Eff es a
-runTimeout = evalData Timeout
+runTimeout = evalStatic Timeout
 
 -- | Lifted 'T.timeout'.
 timeout

--- a/effectful/src/Effectful/Timeout.hs
+++ b/effectful/src/Effectful/Timeout.hs
@@ -17,7 +17,7 @@ type instance EffectStyle Timeout = StaticEffect
 
 -- | Run the 'Timeout' effect.
 runTimeout :: IOE :> es => Eff (Timeout : es) a -> Eff es a
-runTimeout = evalData (StaticEffect Timeout)
+runTimeout = evalData Timeout
 
 -- | Lifted 'T.timeout'.
 timeout

--- a/effectful/tests/ErrorTests.hs
+++ b/effectful/tests/ErrorTests.hs
@@ -8,7 +8,7 @@ import Effectful.Error
 
 errorTests :: TestTree
 errorTests = testGroup "Error"
-  [ testCase "error from interpret" test_errorFromInterpret
+  [ testCase "error from interpretDynamic" test_errorFromInterpret
   ]
 
 test_errorFromInterpret :: Assertion
@@ -32,5 +32,5 @@ nestedErr :: (HasCallStack, NestedErr :> es) => Eff es ()
 nestedErr = send NestedErr
 
 runNestedErr :: Error String :> es => Eff (NestedErr : es) a -> Eff es a
-runNestedErr = interpret $ \_ -> \case
+runNestedErr = runDynamic $ \case
   NestedErr -> throwError "nested error"

--- a/effectful/tests/ErrorTests.hs
+++ b/effectful/tests/ErrorTests.hs
@@ -26,6 +26,8 @@ test_errorFromInterpret = runEff $ do
 data NestedErr :: Effect where
   NestedErr :: NestedErr m ()
 
+type instance EffectStyle NestedErr = DynamicEffect
+
 nestedErr :: (HasCallStack, NestedErr :> es) => Eff es ()
 nestedErr = send NestedErr
 

--- a/effectful/tests/StateTests.hs
+++ b/effectful/tests/StateTests.hs
@@ -115,8 +115,8 @@ putInt = send . PutInt
 
 runHasInt :: Int -> Eff (HasInt : es) a -> Eff es a
 runHasInt n =
-  -- reinterpret with redundant local effects
-  reinterpret (evalState () . evalState n . evalState True) $ \_ -> \case
+  -- rerunDynamic with redundant local effects
+  rerunDynamic (evalState () . evalState n . evalState True) $ \case
     GetInt   -> get
     PutInt i -> put i
 

--- a/effectful/tests/StateTests.hs
+++ b/effectful/tests/StateTests.hs
@@ -105,6 +105,8 @@ data HasInt :: Effect where
   GetInt :: HasInt m Int
   PutInt :: Int -> HasInt m ()
 
+type instance EffectStyle HasInt = DynamicEffect
+
 getInt :: HasInt :> es => Eff es Int
 getInt = send GetInt
 


### PR DESCRIPTION
This is meant more as an example to encourage discussion. I fully expect there to be additional iterations on this as a result of discussions.

---

This PR:
1. Solves the unsafety issue of "static" effects by introducing the `EffectStyle` type family.
2. Tried making the interface more encapsulated.

I think the static/dynamic terminology is very clear and understandable. I also think that the "adapter" terminology is confusing and not understandable in the current implementation.

The syntax looks something like this:

```haskell
type instance EffectStyle MyEffect = DynamicEffect

-- or

type instance EffectStyle MyEffect = StaticEffect
```

When defining the effect the user is not actually concerned with how the effect is represented internally (previously `DataA`, `HandlerA`). The user is more concerned with what type of effect he is trying to define. This is precisely what the `EffectStyle` allows the user to specify. In turn, this allows us to determine what is the internal representation of the effect should be. This also allows us to keep the representation consistent between operations of "static" handlers, thus solving the safety problem.

The internal representation of "dynamic" effects is not poking out of the top-level interface at all. The constructor is not even exported.

Unfortunately, the "static" effect constructor still needs to be exported for Haskell type system reasons.